### PR TITLE
Allow caching file systems

### DIFF
--- a/bioio_nd2/reader.py
+++ b/bioio_nd2/reader.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Tuple
 import nd2
 import xarray as xr
 from bioio_base import constants, exceptions, io, reader, types
+from fsspec.implementations.cached import CachingFileSystem
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
 from ome_types import OME
@@ -42,8 +43,10 @@ class Reader(reader.Reader):
             enforce_exists=True,
             fs_kwargs=fs_kwargs,
         )
-        # Catch non-local file system
-        if not isinstance(self._fs, LocalFileSystem):
+        # Catch non-local file system and non-caching file system
+        if not isinstance(self._fs, LocalFileSystem) and not isinstance(
+            self._fs, CachingFileSystem
+        ):
             raise ValueError(
                 f"Cannot read ND2 from non-local file system. "
                 f"Received URI: {self._path}, which points to {type(self._fs)}."

--- a/bioio_nd2/tests/test_reader.py
+++ b/bioio_nd2/tests/test_reader.py
@@ -205,9 +205,13 @@ def test_ome_metadata(filename: str) -> None:
     assert isinstance(img.ome_metadata, OME)
 
 
-def test_frame_metadata() -> None:
+@pytest.mark.parametrize(
+    "cache",
+    [True, False],
+)
+def test_frame_metadata(cache: bool) -> None:
     uri = LOCAL_RESOURCES_DIR / "ND2_dims_rgb_t3p2c2z3x64y64.nd2"
-    rdr = Reader(uri)
+    rdr = Reader("simplecache::" + str(uri) if cache else uri)
     rdr.set_scene(0)
     assert isinstance(
         rdr.xarray_data.attrs["unprocessed"]["frame"], nd2.structures.FrameMetadata


### PR DESCRIPTION
Allow reading remote nd2 files using caching file systems. Example:

`img = bioio.BioImage("simplecache::s3://foo/test.nd2")`