### PR TITLE
implement _read_indexed and override dims and shape

### DIFF
--- a/bioio_nd2/reader.py
+++ b/bioio_nd2/reader.py
@@ -1,10 +1,14 @@
 import logging
 import re
+from itertools import product
+from numbers import Integral
 from typing import Any, Dict, Tuple
 
 import nd2
+import numpy as np
 import xarray as xr
 from bioio_base import constants, exceptions, io, reader, types
+from bioio_base.dimensions import Dimensions
 from bioio_base.standard_metadata import StandardMetadata
 from fsspec.implementations.cached import CachingFileSystem
 from fsspec.implementations.local import LocalFileSystem
@@ -89,11 +93,197 @@ class Reader(reader.Reader):
             with nd2.ND2File(f) as rdr:
                 return tuple(rdr._position_names())
 
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return self.dims.shape
+
+    @property
+    def dims(self) -> Dimensions:
+        if self._dims is None:
+            dims, shape = self._read_dims_and_shape()
+            self._dims = Dimensions(dims=dims, shape=shape)
+
+        return self._dims
+
+    def _read_dims_and_shape(self) -> Tuple[Tuple[str, ...], Tuple[int, ...]]:
+        with self._fs.open(self._path, "rb") as f:
+            with nd2.ND2File(f) as rdr:
+                dims, shape = self._dims_and_shape_from_nd2(
+                    rdr,
+                    self.current_scene_index,
+                )
+
+        return tuple(dims), tuple(shape)
+
+    @staticmethod
+    def _dims_and_shape_from_nd2(
+        rdr: nd2.ND2File,
+        position: int | None = None,
+    ) -> Tuple[list[str], list[int]]:
+        dims = list(rdr.sizes)
+        shape = list(rdr.shape)
+        coords = rdr._expand_coords(squeeze=False)
+
+        for missing_dim in set(coords).difference(dims):
+            dims.insert(0, missing_dim)
+            shape.insert(0, len(coords[missing_dim]))
+
+        try:
+            position_index = dims.index(nd2.AXIS.POSITION)
+        except ValueError:
+            if position and position > 0:
+                raise IndexError(
+                    f"Position {position} is out of range. Only 1 position available"
+                )
+        else:
+            if position is not None and position >= shape[position_index]:
+                raise IndexError(
+                    f"Position {position} is out of range. "
+                    f"Only {shape[position_index]} positions available"
+                )
+
+            shape[position_index] = 1
+            dims.pop(position_index)
+            shape.pop(position_index)
+
+        return dims, shape
+
+    @staticmethod
+    def _indices_from_dim_spec(dim_spec: Any, size: int) -> list[int]:
+        dim_range = range(size)
+        if isinstance(dim_spec, Integral):
+            return [dim_range[int(dim_spec)]]
+
+        if isinstance(dim_spec, slice):
+            return list(dim_range[dim_spec])
+
+        if isinstance(dim_spec, range):
+            dim_spec = list(dim_spec)
+
+        if isinstance(dim_spec, tuple):
+            dim_spec = list(dim_spec)
+
+        if isinstance(dim_spec, list):
+            return [dim_range[int(index)] for index in dim_spec]
+
+        raise TypeError(f"Unsupported dimension indexer: {type(dim_spec).__name__}")
+
+    @staticmethod
+    def _local_dim_spec(dim_spec: Any, size: int) -> Any:
+        if isinstance(dim_spec, Integral):
+            return 0
+
+        if isinstance(dim_spec, slice):
+            return slice(None)
+
+        return list(range(size))
+
+    @staticmethod
+    def _reshape_frame_to_dims(
+        frame: np.ndarray,
+        current_dims: list[str],
+        target_dims: list[str],
+        shape_by_dim: Dict[str, int],
+    ) -> np.ndarray:
+        if current_dims:
+            frame = frame.reshape(tuple(shape_by_dim[dim] for dim in current_dims))
+        else:
+            frame = frame.reshape(())
+
+        for dim in target_dims:
+            if dim not in current_dims:
+                frame = np.expand_dims(frame, axis=0)
+                current_dims.insert(0, dim)
+
+        if current_dims != target_dims:
+            frame = frame.transpose([current_dims.index(dim) for dim in target_dims])
+
+        return frame
+
     def _read_delayed(self) -> xr.DataArray:
         return self._xarr_reformat(delayed=True)
 
     def _read_immediate(self) -> xr.DataArray:
         return self._xarr_reformat(delayed=False)
+
+    def _read_indexed(self, given_dims: str, dim_specs: list) -> np.ndarray:
+        position = self.current_scene_index
+        with self._fs.open(self._path, "rb") as f:
+            with nd2.ND2File(f) as rdr:
+                dims, shape = self._dims_and_shape_from_nd2(
+                    rdr,
+                    position,
+                )
+                shape_by_dim = dict(zip(dims, shape))
+                frame_coord_dims = nd2.AXIS.frame_coords()
+                coord_dims = [
+                    dim for dim in rdr.sizes if dim not in frame_coord_dims
+                ]
+                frame_dims = [dim for dim in given_dims if dim in frame_coord_dims]
+                current_frame_dims = [
+                    dim for dim in rdr.sizes if dim in frame_coord_dims
+                ]
+
+                selected_indices = {
+                    dim: self._indices_from_dim_spec(
+                        dim_specs[dim_index],
+                        shape_by_dim[dim],
+                    )
+                    for dim_index, dim in enumerate(given_dims)
+                }
+                subset_shape = tuple(
+                    len(selected_indices[dim]) for dim in given_dims
+                )
+                subset = np.empty(subset_shape, dtype=rdr.dtype)
+                local_indexer = tuple(
+                    self._local_dim_spec(dim_specs[dim_index], subset_shape[dim_index])
+                    for dim_index in range(len(given_dims))
+                )
+
+                if 0 in subset_shape:
+                    return subset[local_indexer]
+
+                coord_choices = []
+                for dim in coord_dims:
+                    if dim == nd2.AXIS.POSITION:
+                        coord_choices.append([(0, position)])
+                    else:
+                        coord_choices.append(list(enumerate(selected_indices[dim])))
+
+                for coord_selection in product(*coord_choices):
+                    coord_indexes = tuple(index for _, index in coord_selection)
+                    if not coord_dims:
+                        frame_index = 0
+                    else:
+                        frame_index = rdr._seq_index_from_coords(coord_indexes)
+
+                    frame = np.asarray(rdr.read_frame(frame_index))
+                    frame = self._reshape_frame_to_dims(
+                        frame,
+                        current_frame_dims.copy(),
+                        frame_dims,
+                        shape_by_dim,
+                    )
+
+                    for frame_axis, dim in enumerate(frame_dims):
+                        frame = np.take(
+                            frame,
+                            selected_indices[dim],
+                            axis=frame_axis,
+                        )
+
+                    coord_ordinals = {
+                        dim: ordinal
+                        for dim, (ordinal, _) in zip(coord_dims, coord_selection)
+                        if dim != nd2.AXIS.POSITION
+                    }
+                    subset_index = tuple(
+                        coord_ordinals[dim] if dim in coord_ordinals else slice(None)
+                        for dim in given_dims
+                    )
+                    subset[subset_index] = frame
+
+        return subset[local_indexer]
 
     def _xarr_reformat(self, delayed: bool) -> xr.DataArray:
         with self._fs.open(self._path, "rb") as f:

--- a/bioio_nd2/reader.py
+++ b/bioio_nd2/reader.py
@@ -2,7 +2,7 @@ import logging
 import re
 from itertools import product
 from numbers import Integral
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import nd2
 import numpy as np
@@ -53,6 +53,9 @@ class Reader(reader.Reader):
     """
 
     _scene_to_well_map: Dict[int, WellPosition | None] | None = None
+    # must match the bioio-base Reader's signature for the `dims` property,
+    # which is cached here for mypy type checking reasons
+    _dims: Optional[Dimensions] = None
 
     @staticmethod
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
@@ -216,9 +219,7 @@ class Reader(reader.Reader):
                 )
                 shape_by_dim = dict(zip(dims, shape))
                 frame_coord_dims = nd2.AXIS.frame_coords()
-                coord_dims = [
-                    dim for dim in rdr.sizes if dim not in frame_coord_dims
-                ]
+                coord_dims = [dim for dim in rdr.sizes if dim not in frame_coord_dims]
                 frame_dims = [dim for dim in given_dims if dim in frame_coord_dims]
                 current_frame_dims = [
                     dim for dim in rdr.sizes if dim in frame_coord_dims
@@ -231,9 +232,7 @@ class Reader(reader.Reader):
                     )
                     for dim_index, dim in enumerate(given_dims)
                 }
-                subset_shape = tuple(
-                    len(selected_indices[dim]) for dim in given_dims
-                )
+                subset_shape = tuple(len(selected_indices[dim]) for dim in given_dims)
                 subset = np.empty(subset_shape, dtype=rdr.dtype)
                 local_indexer = tuple(
                     self._local_dim_spec(dim_specs[dim_index], subset_shape[dim_index])

--- a/bioio_nd2/tests/test_reader.py
+++ b/bioio_nd2/tests/test_reader.py
@@ -272,7 +272,7 @@ def test_read_indexed_reads_only_requested_nd2_frames(
     def fail_delayed_read() -> xr.DataArray:
         raise AssertionError("_read_delayed should not be used for indexed reads")
 
-    rdr._read_delayed = fail_delayed_read
+    monkeypatch.setattr(rdr, "_read_delayed", fail_delayed_read)
 
     actual = rdr._read_indexed(
         "TCYX",
@@ -445,7 +445,7 @@ def test_dims_and_shape_use_nd2_metadata_without_xarray_dask_data(
     def fail_delayed_read() -> xr.DataArray:
         raise AssertionError("_read_delayed should not be used for dims or shape")
 
-    rdr._read_delayed = fail_delayed_read
+    monkeypatch.setattr(rdr, "_read_delayed", fail_delayed_read)
 
     assert rdr.dims.order == "CYX"
     assert rdr.shape == (1, 4, 5)

--- a/bioio_nd2/tests/test_reader.py
+++ b/bioio_nd2/tests/test_reader.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from contextlib import nullcontext
 from typing import Any, List, Tuple, Union
 
 import numpy as np
 import pytest
+import xarray as xr
 from bioio_base import exceptions, test_utilities
 from ome_types import OME
 
@@ -216,3 +218,240 @@ def test_frame_metadata(cache: bool) -> None:
     assert isinstance(
         rdr.xarray_data.attrs["unprocessed"]["frame"], nd2.structures.FrameMetadata
     )
+
+
+def test_read_indexed_reads_only_requested_nd2_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = np.arange(2 * 2 * 3 * 4 * 5).reshape(2, 2, 3, 4, 5)
+    frame_reads = []
+
+    class FakeND2File:
+        sizes = {"P": 2, "T": 2, "C": 3, "Y": 4, "X": 5}
+        shape = (2, 2, 3, 4, 5)
+        dtype = data.dtype
+
+        def __init__(self, file: object) -> None:
+            pass
+
+        def __enter__(self) -> "FakeND2File":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def _expand_coords(self, squeeze: bool = True) -> dict[str, object]:
+            assert squeeze is False
+            return {
+                nd2.AXIS.POSITION: range(2),
+                "T": range(2),
+                "C": range(3),
+                "Y": range(4),
+                "X": range(5),
+            }
+
+        def _seq_index_from_coords(self, coords: Tuple[int, ...]) -> int:
+            return int(np.ravel_multi_index(coords, (2, 2)))
+
+        def read_frame(self, frame_index: int) -> np.ndarray:
+            frame_reads.append(frame_index)
+            return data.reshape(4, 3, 4, 5)[frame_index]
+
+    class FakeFS:
+        def open(self, path: str, mode: str) -> Any:
+            return nullcontext(object())
+
+    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
+
+    rdr = Reader.__new__(Reader)
+    rdr._fs = FakeFS()
+    rdr._path = "example.nd2"
+    rdr._dims = None
+    rdr._current_scene_index = 1
+
+    def fail_delayed_read() -> xr.DataArray:
+        raise AssertionError("_read_delayed should not be used for indexed reads")
+
+    rdr._read_delayed = fail_delayed_read
+
+    actual = rdr._read_indexed(
+        "TCYX",
+        [
+            slice(None),
+            slice(1, 3),
+            slice(1, 4),
+            slice(0, 5, 2),
+        ],
+    )
+
+    np.testing.assert_array_equal(
+        actual,
+        data[1, :, 1:3, 1:4, 0:5:2],
+    )
+    assert frame_reads == [2, 3]
+
+    frame_reads.clear()
+    dim_specs = [
+        slice(None),
+        [0, 2],
+        [1, 3],
+        slice(0, 5, 2),
+    ]
+    actual = rdr._read_indexed("TCYX", dim_specs)
+
+    np.testing.assert_array_equal(
+        actual,
+        data[1][tuple(dim_specs)],
+    )
+    assert frame_reads == [2, 3]
+
+    frame_reads.clear()
+    rdr._current_scene_index = 0
+    actual = rdr._read_indexed(
+        "TCYX",
+        [
+            slice(None),
+            slice(1, 3),
+            slice(1, 4),
+            slice(0, 5, 2),
+        ],
+    )
+
+    np.testing.assert_array_equal(
+        actual,
+        data[0, :, 1:3, 1:4, 0:5:2],
+    )
+    assert frame_reads == [0, 1]
+
+    rdr._current_scene_index = 2
+    with pytest.raises(IndexError, match="Position 2 is out of range"):
+        rdr._read_indexed("TCYX", dim_specs)
+
+
+def test_read_indexed_reads_single_middle_plane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = np.arange(3 * 5 * 7 * 4 * 6 * 8).reshape(3, 5, 7, 4, 6, 8)
+    frame_reads = []
+
+    class FakeND2File:
+        sizes = {
+            nd2.AXIS.POSITION: 3,
+            "T": 5,
+            "Z": 7,
+            "C": 4,
+            "Y": 6,
+            "X": 8,
+        }
+        shape = (3, 5, 7, 4, 6, 8)
+        dtype = data.dtype
+
+        def __init__(self, file: object) -> None:
+            pass
+
+        def __enter__(self) -> "FakeND2File":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def _expand_coords(self, squeeze: bool = True) -> dict[str, object]:
+            assert squeeze is False
+            return {
+                nd2.AXIS.POSITION: range(3),
+                "T": range(5),
+                "Z": range(7),
+                "C": range(4),
+                "Y": range(6),
+                "X": range(8),
+            }
+
+        def _seq_index_from_coords(self, coords: Tuple[int, ...]) -> int:
+            return int(np.ravel_multi_index(coords, (3, 5, 7)))
+
+        def read_frame(self, frame_index: int) -> np.ndarray:
+            frame_reads.append(frame_index)
+            return data.reshape(3 * 5 * 7, 4, 6, 8)[frame_index]
+
+    class FakeFS:
+        def open(self, path: str, mode: str) -> Any:
+            return nullcontext(object())
+
+    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
+
+    rdr = Reader.__new__(Reader)
+    rdr._fs = FakeFS()
+    rdr._path = "example.nd2"
+    rdr._dims = None
+    rdr._current_scene_index = 1
+
+    actual = rdr._read_indexed(
+        "TZCYX",
+        [
+            2,
+            3,
+            2,
+            slice(None),
+            slice(None),
+        ],
+    )
+
+    np.testing.assert_array_equal(actual, data[1, 2, 3, 2])
+    assert frame_reads == [int(np.ravel_multi_index((1, 2, 3), (3, 5, 7)))]
+
+
+def test_dims_and_shape_use_nd2_metadata_without_xarray_dask_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeND2File:
+        sizes = {nd2.AXIS.POSITION: 3, "Y": 4, "X": 5}
+        shape = (3, 4, 5)
+
+        def __init__(self, file: object) -> None:
+            pass
+
+        def __enter__(self) -> "FakeND2File":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def _expand_coords(self, squeeze: bool = True) -> dict[str, object]:
+            assert squeeze is False
+            return {
+                nd2.AXIS.POSITION: range(3),
+                "Y": range(4),
+                "X": range(5),
+                "C": ["channel"],
+            }
+
+    class FakeFS:
+        def __init__(self) -> None:
+            self.open_count = 0
+
+        def open(self, path: str, mode: str) -> Any:
+            self.open_count += 1
+            return nullcontext(object())
+
+    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
+
+    fs = FakeFS()
+    rdr = Reader.__new__(Reader)
+    rdr._fs = fs
+    rdr._path = "example.nd2"
+    rdr._dims = None
+    rdr._current_scene_index = 2
+
+    def fail_delayed_read() -> xr.DataArray:
+        raise AssertionError("_read_delayed should not be used for dims or shape")
+
+    rdr._read_delayed = fail_delayed_read
+
+    assert rdr.dims.order == "CYX"
+    assert rdr.shape == (1, 4, 5)
+    assert fs.open_count == 1
+
+    rdr._dims = None
+    rdr._current_scene_index = 3
+    with pytest.raises(IndexError, match="Position 3 is out of range"):
+        rdr.dims

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "bioio-base>=3.0.0",
+  "bioio-base @ git+https://github.com/bioio-devs/bioio-base.git@feat/fast-subslice-reads",
   "nd2[legacy]>=0.10.3",
   "dask[array]>=2021.4.1",
   "fsspec>=2022.8.0",


### PR DESCRIPTION
This is the implementation of `_read_indexed` for optimal per-plane reads, and an overridden `dims` and `shape` properties.   This pr requires the changes in https://github.com/bioio-devs/bioio-base/pull/70 and (temporarily) depends strictly on that branch of bioio-base.