### PR TITLE
Extract well row/column for split single-position ND2 files

### DIFF
--- a/bioio_nd2/plates.py
+++ b/bioio_nd2/plates.py
@@ -245,28 +245,96 @@ PLATE_96 = Plate(
 ###############################################################################
 
 
-def extract_position_stage_xy_um(
+def _stage_xy_from_events(
     rdr: nd2.ND2File,
+    scene_to_position: Dict[int, int],
 ) -> Dict[int, Tuple[float, float]]:
     """
-    Extract stage XY positions (µm) for each ND2 position index.
+    Recover per-position stage XY (µm) from the acquisition events table.
+
+    Used as a fallback when a split single-position file no longer carries an
+    ``XYPosLoop``. Coordinates use the same negated sign convention.
 
     Returns
     -------
     Dict[int, Tuple[float, float]]
-        Mapping of ND2 position index → (x_um, y_um)
-
+        Mapping of ND2 position index → (x_um, y_um). Empty if unavailable.
     """
-    for exp in rdr.experiment:
-        if "XYPosLoop" in str(exp):
-            points = exp.parameters.points
-            break
-    else:
+    try:
+        events = rdr.events()
+    except Exception as exc:
+        log.debug("Could not read events table: %s", exc)
+        return {}
+
+    if not events:
+        return {}
+
+    # The coordinate column names include the µm unit; match on a prefix so we
+    # are robust to the unit's encoding.
+    sample = events[0]
+    x_key = next((k for k in sample if "X Coord" in k), None)
+    y_key = next((k for k in sample if "Y Coord" in k), None)
+    if x_key is None or y_key is None:
+        return {}
+
+    num_frames = len(events)
+    num_scenes = (max(scene_to_position) + 1) if scene_to_position else 1
+    # Events are ordered by acquisition sequence; for multi-position files the
+    # position is the outermost loop, so each scene's frames are contiguous.
+    frames_per_scene = max(1, num_frames // num_scenes)
+
+    position_xy: Dict[int, Tuple[float, float]] = {}
+    for scene_index, pos_index in scene_to_position.items():
+        if pos_index in position_xy:
+            continue
+        frame_index = min(scene_index * frames_per_scene, num_frames - 1)
+        row = events[frame_index]
+        x, y = row.get(x_key), row.get(y_key)
+        if x is not None and y is not None:
+            position_xy[pos_index] = (-x, -y)
+
+    return position_xy
+
+
+def extract_position_stage_xy_um(
+    rdr: nd2.ND2File,
+    num_scenes: Optional[int] = None,
+) -> Tuple[Dict[int, Tuple[float, float]], bool]:
+    """
+    Extract stage XY positions (µm) for each ND2 position index.
+
+    Falls back to the events table when the file has no ``XYPosLoop``
+    (e.g. single-position files split from a multi-position acquisition).
+
+    Returns
+    -------
+    Tuple[Dict[int, Tuple[float, float]], bool]
+        Mapping of ND2 position index → (x_um, y_um), and whether the
+        events-table fallback was used rather than the ``XYPosLoop``.
+    """
+    # Preferred: the XYPosLoop carries one point per stage position.
+    try:
+        for exp in rdr.experiment:
+            if "XYPosLoop" in str(exp):
+                points = exp.parameters.points
+                return {
+                    i: (-p.stagePositionUm.x, -p.stagePositionUm.y)
+                    for i, p in enumerate(points)
+                }, False
+    except Exception as exc:
+        log.debug("Could not read XYPosLoop, falling back to frames: %s", exc)
+
+    # Fallback: recover the stage position from the events table.
+    if num_scenes is None:
+        num_scenes = rdr.sizes.get("P", 1)
+
+    scene_to_position = extract_scene_to_position_index(rdr, num_scenes)
+    position_xy = _stage_xy_from_events(rdr, scene_to_position)
+
+    if not position_xy:
         raise RuntimeError("ND2 file does not contain XY position metadata.")
 
-    return {
-        i: (-p.stagePositionUm.x, -p.stagePositionUm.y) for i, p in enumerate(points)
-    }
+    return position_xy, True
 
 
 def extract_scene_to_position_index(
@@ -311,9 +379,12 @@ def find_closest_well(
     wells: Iterable[PlateWell],
     *,
     plate: Plate,
+    mode: Optional[WellAssignmentMode] = None,
 ) -> Optional[WellPosition]:
     """
-    Assign a stage position to a logical well using the plate's assignment policy.
+    Assign a stage position to a logical well using an assignment policy.
+
+    When ``mode`` is None the plate's configured ``assignment_mode`` is used.
 
     Returns
     -------
@@ -328,7 +399,7 @@ def find_closest_well(
 
     dist = np.sqrt((x - best.center_x) ** 2 + (y - best.center_y) ** 2)
 
-    mode = plate.assignment_mode
+    mode = mode if mode is not None else plate.assignment_mode
 
     if mode is WellAssignmentMode.CLOSEST:
         return WellPosition(best.row, best.col)
@@ -352,17 +423,19 @@ def map_scenes_to_wells(
     wells: Iterable[PlateWell],
     *,
     plate: Plate,
+    mode: Optional[WellAssignmentMode] = None,
 ) -> Dict[int, Optional[WellPosition]]:
     """
     Map absolute scene indices to logical well positions.
 
     This is the primary orchestration function used by the ND2 Reader.
+    ``mode`` overrides the plate's assignment policy when provided.
 
     Returns
     -------
     Dict[int, Optional[WellPosition]]
         Mapping of absolute scene index to logical well position. If the
-        plate's assignment policy rejects a position (e.g. strict physical
+        assignment policy rejects a position (e.g. strict physical
         containment), the value for that scene will be ``None``.
     """
     mapping: Dict[int, Optional[WellPosition]] = {}
@@ -374,6 +447,7 @@ def map_scenes_to_wells(
             y,
             wells,
             plate=plate,
+            mode=mode,
         )
 
     return mapping

--- a/bioio_nd2/plates.py
+++ b/bioio_nd2/plates.py
@@ -299,7 +299,7 @@ def _stage_xy_from_events(
 def extract_position_stage_xy_um(
     rdr: nd2.ND2File,
     num_scenes: Optional[int] = None,
-) -> Tuple[Dict[int, Tuple[float, float]], bool]:
+) -> Dict[int, Tuple[float, float]]:
     """
     Extract stage XY positions (µm) for each ND2 position index.
 
@@ -308,9 +308,8 @@ def extract_position_stage_xy_um(
 
     Returns
     -------
-    Tuple[Dict[int, Tuple[float, float]], bool]
-        Mapping of ND2 position index → (x_um, y_um), and whether the
-        events-table fallback was used rather than the ``XYPosLoop``.
+    Dict[int, Tuple[float, float]]
+        Mapping of ND2 position index → (x_um, y_um)
     """
     # Preferred: the XYPosLoop carries one point per stage position.
     try:
@@ -320,7 +319,7 @@ def extract_position_stage_xy_um(
                 return {
                     i: (-p.stagePositionUm.x, -p.stagePositionUm.y)
                     for i, p in enumerate(points)
-                }, False
+                }
     except Exception as exc:
         log.debug("Could not read XYPosLoop, falling back to frames: %s", exc)
 
@@ -334,7 +333,7 @@ def extract_position_stage_xy_um(
     if not position_xy:
         raise RuntimeError("ND2 file does not contain XY position metadata.")
 
-    return position_xy, True
+    return position_xy
 
 
 def extract_scene_to_position_index(
@@ -379,12 +378,9 @@ def find_closest_well(
     wells: Iterable[PlateWell],
     *,
     plate: Plate,
-    mode: Optional[WellAssignmentMode] = None,
 ) -> Optional[WellPosition]:
     """
-    Assign a stage position to a logical well using an assignment policy.
-
-    When ``mode`` is None the plate's configured ``assignment_mode`` is used.
+    Assign a stage position to a logical well using the plate's assignment policy.
 
     Returns
     -------
@@ -399,7 +395,7 @@ def find_closest_well(
 
     dist = np.sqrt((x - best.center_x) ** 2 + (y - best.center_y) ** 2)
 
-    mode = mode if mode is not None else plate.assignment_mode
+    mode = plate.assignment_mode
 
     if mode is WellAssignmentMode.CLOSEST:
         return WellPosition(best.row, best.col)
@@ -423,19 +419,17 @@ def map_scenes_to_wells(
     wells: Iterable[PlateWell],
     *,
     plate: Plate,
-    mode: Optional[WellAssignmentMode] = None,
 ) -> Dict[int, Optional[WellPosition]]:
     """
     Map absolute scene indices to logical well positions.
 
     This is the primary orchestration function used by the ND2 Reader.
-    ``mode`` overrides the plate's assignment policy when provided.
 
     Returns
     -------
     Dict[int, Optional[WellPosition]]
         Mapping of absolute scene index to logical well position. If the
-        assignment policy rejects a position (e.g. strict physical
+        plate's assignment policy rejects a position (e.g. strict physical
         containment), the value for that scene will be ``None``.
     """
     mapping: Dict[int, Optional[WellPosition]] = {}
@@ -447,7 +441,6 @@ def map_scenes_to_wells(
             y,
             wells,
             plate=plate,
-            mode=mode,
         )
 
     return mapping

--- a/bioio_nd2/plates.py
+++ b/bioio_nd2/plates.py
@@ -247,27 +247,16 @@ PLATE_96 = Plate(
 
 def _stage_xy_from_events(
     rdr: nd2.ND2File,
-    scene_to_position: Dict[int, int],
-) -> Dict[int, Tuple[float, float]]:
+) -> Optional[Tuple[float, float]]:
     """
-    Recover per-position stage XY (µm) from the acquisition events table.
+    Recover the stage XY (µm) of a single-position file from the events table.
 
-    Used as a fallback when a split single-position file no longer carries an
-    ``XYPosLoop``. Coordinates use the same negated sign convention.
-
-    Returns
-    -------
-    Dict[int, Tuple[float, float]]
-        Mapping of ND2 position index → (x_um, y_um). Empty if unavailable.
+    Used as a fallback when a split file no longer carries an ``XYPosLoop``.
+    Returns the position with the same negated sign convention, or None.
     """
-    try:
-        events = rdr.events()
-    except Exception as exc:
-        log.debug("Could not read events table: %s", exc)
-        return {}
-
+    events = rdr.events()
     if not events:
-        return {}
+        return None
 
     # The coordinate column names include the µm unit; match on a prefix so we
     # are robust to the unit's encoding.
@@ -275,30 +264,17 @@ def _stage_xy_from_events(
     x_key = next((k for k in sample if "X Coord" in k), None)
     y_key = next((k for k in sample if "Y Coord" in k), None)
     if x_key is None or y_key is None:
-        return {}
+        return None
 
-    num_frames = len(events)
-    num_scenes = (max(scene_to_position) + 1) if scene_to_position else 1
-    # Events are ordered by acquisition sequence; for multi-position files the
-    # position is the outermost loop, so each scene's frames are contiguous.
-    frames_per_scene = max(1, num_frames // num_scenes)
+    x, y = sample.get(x_key), sample.get(y_key)
+    if x is None or y is None:
+        return None
 
-    position_xy: Dict[int, Tuple[float, float]] = {}
-    for scene_index, pos_index in scene_to_position.items():
-        if pos_index in position_xy:
-            continue
-        frame_index = min(scene_index * frames_per_scene, num_frames - 1)
-        row = events[frame_index]
-        x, y = row.get(x_key), row.get(y_key)
-        if x is not None and y is not None:
-            position_xy[pos_index] = (-x, -y)
-
-    return position_xy
+    return (-x, -y)
 
 
 def extract_position_stage_xy_um(
     rdr: nd2.ND2File,
-    num_scenes: Optional[int] = None,
 ) -> Dict[int, Tuple[float, float]]:
     """
     Extract stage XY positions (µm) for each ND2 position index.
@@ -311,29 +287,21 @@ def extract_position_stage_xy_um(
     Dict[int, Tuple[float, float]]
         Mapping of ND2 position index → (x_um, y_um)
     """
-    # Preferred: the XYPosLoop carries one point per stage position.
-    try:
-        for exp in rdr.experiment:
-            if "XYPosLoop" in str(exp):
-                points = exp.parameters.points
-                return {
-                    i: (-p.stagePositionUm.x, -p.stagePositionUm.y)
-                    for i, p in enumerate(points)
-                }
-    except Exception as exc:
-        log.debug("Could not read XYPosLoop, falling back to frames: %s", exc)
+    for exp in rdr.experiment:
+        if "XYPosLoop" in str(exp):
+            points = exp.parameters.points
+            return {
+                i: (-p.stagePositionUm.x, -p.stagePositionUm.y)
+                for i, p in enumerate(points)
+            }
 
-    # Fallback: recover the stage position from the events table.
-    if num_scenes is None:
-        num_scenes = rdr.sizes.get("P", 1)
-
-    scene_to_position = extract_scene_to_position_index(rdr, num_scenes)
-    position_xy = _stage_xy_from_events(rdr, scene_to_position)
-
-    if not position_xy:
+    # No XYPosLoop: single-position file. Recover the logged stage position
+    # from the events table.
+    xy = _stage_xy_from_events(rdr)
+    if xy is None:
         raise RuntimeError("ND2 file does not contain XY position metadata.")
 
-    return position_xy
+    return {0: xy}
 
 
 def extract_scene_to_position_index(

--- a/bioio_nd2/reader.py
+++ b/bioio_nd2/reader.py
@@ -13,6 +13,7 @@ from ome_types import OME
 
 from .plates import (
     Plate,
+    WellAssignmentMode,
     WellPosition,
     extract_position_stage_xy_um,
     extract_scene_to_position_index,
@@ -87,7 +88,25 @@ class Reader(reader.Reader):
     def scenes(self) -> Tuple[str, ...]:
         with self._fs.open(self._path, "rb") as f:
             with nd2.ND2File(f) as rdr:
-                return tuple(rdr._position_names())
+                try:
+                    return tuple(rdr._position_names())
+                except Exception as exc:
+                    # Some files carry experiment metadata that `nd2` cannot
+                    # parse (e.g. unknown loop types). Fall back to a generic
+                    # scene naming so the file is still readable.
+                    log.warning(
+                        "Failed to read ND2 position names, falling back to "
+                        "generic scene names: %s",
+                        exc,
+                    )
+                    # `rdr.sizes` also parses the experiment, so it may raise
+                    # the same error. Default to a single position in that case
+                    # (these unparseable files are single-position splits).
+                    try:
+                        num_positions = rdr.sizes.get("P", 1)
+                    except Exception:
+                        num_positions = 1
+                    return tuple(f"XYPos:{i}" for i in range(num_positions))
 
     def _read_delayed(self) -> xr.DataArray:
         return self._xarr_reformat(delayed=True)
@@ -188,16 +207,26 @@ class Reader(reader.Reader):
             with nd2.ND2File(f) as rdr:
                 wells = self._plate.generate_wells()
 
-                position_xy = extract_position_stage_xy_um(rdr)
-                scene_to_position = extract_scene_to_position_index(
-                    rdr, num_scenes=len(self.scenes)
+                num_scenes = len(self.scenes)
+                position_xy, used_fallback = extract_position_stage_xy_um(
+                    rdr, num_scenes=num_scenes
                 )
+                scene_to_position = extract_scene_to_position_index(
+                    rdr, num_scenes=num_scenes
+                )
+
+        # Positions recovered from the events-table fallback are less precise
+        # than XYPosLoop, so require the stage position to be near a well
+        # before assigning it. This nulls out off-plate images (e.g. a
+        # calibration target) instead of snapping them to the nearest well.
+        mode = WellAssignmentMode.HALF_SPACING if used_fallback else None
 
         self._scene_to_well_map = map_scenes_to_wells(
             scene_to_position,
             position_xy,
             wells,
             plate=self._plate,
+            mode=mode,
         )
 
         return self._scene_to_well_map

--- a/bioio_nd2/reader.py
+++ b/bioio_nd2/reader.py
@@ -13,7 +13,6 @@ from ome_types import OME
 
 from .plates import (
     Plate,
-    WellAssignmentMode,
     WellPosition,
     extract_position_stage_xy_um,
     extract_scene_to_position_index,
@@ -207,26 +206,16 @@ class Reader(reader.Reader):
             with nd2.ND2File(f) as rdr:
                 wells = self._plate.generate_wells()
 
-                num_scenes = len(self.scenes)
-                position_xy, used_fallback = extract_position_stage_xy_um(
-                    rdr, num_scenes=num_scenes
-                )
+                position_xy = extract_position_stage_xy_um(rdr)
                 scene_to_position = extract_scene_to_position_index(
-                    rdr, num_scenes=num_scenes
+                    rdr, num_scenes=len(self.scenes)
                 )
-
-        # Positions recovered from the events-table fallback are less precise
-        # than XYPosLoop, so require the stage position to be near a well
-        # before assigning it. This nulls out off-plate images (e.g. a
-        # calibration target) instead of snapping them to the nearest well.
-        mode = WellAssignmentMode.HALF_SPACING if used_fallback else None
 
         self._scene_to_well_map = map_scenes_to_wells(
             scene_to_position,
             position_xy,
             wells,
             plate=self._plate,
-            mode=mode,
         )
 
         return self._scene_to_well_map

--- a/bioio_nd2/reader.py
+++ b/bioio_nd2/reader.py
@@ -87,25 +87,7 @@ class Reader(reader.Reader):
     def scenes(self) -> Tuple[str, ...]:
         with self._fs.open(self._path, "rb") as f:
             with nd2.ND2File(f) as rdr:
-                try:
-                    return tuple(rdr._position_names())
-                except Exception as exc:
-                    # Some files carry experiment metadata that `nd2` cannot
-                    # parse (e.g. unknown loop types). Fall back to a generic
-                    # scene naming so the file is still readable.
-                    log.warning(
-                        "Failed to read ND2 position names, falling back to "
-                        "generic scene names: %s",
-                        exc,
-                    )
-                    # `rdr.sizes` also parses the experiment, so it may raise
-                    # the same error. Default to a single position in that case
-                    # (these unparseable files are single-position splits).
-                    try:
-                        num_positions = rdr.sizes.get("P", 1)
-                    except Exception:
-                        num_positions = 1
-                    return tuple(f"XYPos:{i}" for i in range(num_positions))
+                return tuple(rdr._position_names())
 
     def _read_delayed(self) -> xr.DataArray:
         return self._xarr_reformat(delayed=True)

--- a/bioio_nd2/tests/test_standard_metadata.py
+++ b/bioio_nd2/tests/test_standard_metadata.py
@@ -139,12 +139,13 @@ def test_nd2_standard_metadata(filename: str, expected: dict[str, Any]) -> None:
 @pytest.mark.parametrize(
     "filename, scene_index, expected_row, expected_col",
     [
-        # Case 1: ND2 file without XYPosLoop fails to produce
+        # Case 1: ND2 file without an XYPosLoop. The stage position is
+        # recovered from the events table and lands inside well D6.
         (
             "ND2_maxime_BF007.nd2",
             0,
-            None,
-            None,
+            "D",
+            "6",
         ),
         # Case 2: Plate scan file, scene maps to E3
         (

--- a/bioio_nd2/tests/test_standard_metadata.py
+++ b/bioio_nd2/tests/test_standard_metadata.py
@@ -90,7 +90,7 @@ from .conftest import LOCAL_RESOURCES_DIR
             "Argo_sphere_water.nd2",
             {
                 "Binning": "1x1",
-                "Column": None,
+                "Column": "7",
                 "Dimensions Present": "CZYX",
                 "Image Size C": 1,
                 "Image Size T": None,
@@ -115,7 +115,7 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Pixel Size Y": 0.108333333333333,
                 "Pixel Size Z": 0.5,
                 "Position Index": None,
-                "Row": None,
+                "Row": "E",
                 "Timelapse": False,
                 "Timelapse Interval": None,
                 "Total Time Duration": datetime.timedelta(microseconds=245184),


### PR DESCRIPTION
Closes #45

## Summary

Single-position ND2 files split out of a multi-position acquisition no longer carry an `XYPosLoop`, so `row`/`column` standard-metadata extraction returned `None`. This recovers the well from the events position data that *does* survive the split. 

## Changes

- **`plates.py`** (all logic) — when there is no `XYPosLoop`, recover the per-position stage coordinate from the **acquisition events table** (the real logged position). `frame_metadata().position` reports a stale reference coordinate and is not used. Fallback positions use the plate's normal assignment policy (`CLOSEST`), same as the `XYPosLoop` path.
- **`tests`** — `ND2_maxime_BF007` now resolves to `D6` and `Argo_sphere_water` to `E7` (positions recovered from the events table; previously `None`)


## Validation
The failures here are due to failed splitting. The important data is that there was minimal mismatch from human label and derived well.
<img width="584" height="191" alt="Screenshot 2026-06-23 at 12 56 45 PM" src="https://github.com/user-attachments/assets/45e23408-b49b-4501-add1-a544f1620906" />