### PR TITLE
Feature Request: Add indexed reads for faster nd2 sub-region access

### DIFF
--- a/bioio_nd2/reader.py
+++ b/bioio_nd2/reader.py
@@ -1,8 +1,9 @@
 import logging
 import re
+from contextlib import contextmanager
 from itertools import product
 from numbers import Integral
-from typing import Any, Dict, Optional, Tuple, cast
+from typing import Any, Dict, Iterator, Optional, Tuple, cast
 
 import nd2
 import numpy as np
@@ -91,11 +92,31 @@ class Reader(reader.Reader):
 
         self._is_supported_image(self._fs, self._path)
 
+    @contextmanager
+    def _open_nd2(self) -> Iterator[nd2.ND2File]:
+        """Open the backing ND2 file, memory-mapping it when possible.
+
+        For a local filesystem the path is handed directly to ``nd2.ND2File`` so
+        the SDK memory-maps the file. Repeated ``read_frame`` calls then read
+        from OS-cached pages and benefit from kernel read-ahead, instead of
+        streaming every plane through a Python file object. Memory-mapping maps
+        the file in place and never copies it, which matters for very large ND2s
+        that cannot be staged to local disk. Remote sources (a
+        ``CachingFileSystem``) cannot be memory-mapped, so they fall back to an
+        fsspec handle.
+        """
+        if isinstance(self._fs, LocalFileSystem):
+            with nd2.ND2File(self._path) as rdr:
+                yield rdr
+        else:
+            with self._fs.open(self._path, "rb") as f:
+                with nd2.ND2File(f) as rdr:
+                    yield rdr
+
     @property
     def scenes(self) -> Tuple[str, ...]:
-        with self._fs.open(self._path, "rb") as f:
-            with nd2.ND2File(f) as rdr:
-                return tuple(rdr._position_names())
+        with self._open_nd2() as rdr:
+            return tuple(rdr._position_names())
 
     @property
     def shape(self) -> Tuple[int, ...]:
@@ -116,9 +137,8 @@ class Reader(reader.Reader):
             Data-type of the image array's elements.
         """
         if self._dtype is None:
-            with self._fs.open(self._path, "rb") as f:
-                with nd2.ND2File(f) as rdr:
-                    self._dtype = rdr.dtype
+            with self._open_nd2() as rdr:
+                self._dtype = rdr.dtype
 
         return self._dtype
 
@@ -148,12 +168,11 @@ class Reader(reader.Reader):
         shape: Tuple[int, ...]
             The size of each dimension, in the same order as ``dims``.
         """
-        with self._fs.open(self._path, "rb") as f:
-            with nd2.ND2File(f) as rdr:
-                dims, shape = self._dims_and_shape_from_nd2(
-                    rdr,
-                    self.current_scene_index,
-                )
+        with self._open_nd2() as rdr:
+            dims, shape = self._dims_and_shape_from_nd2(
+                rdr,
+                self.current_scene_index,
+            )
 
         return tuple(dims), tuple(shape)
 
@@ -356,78 +375,84 @@ class Reader(reader.Reader):
             The indexed image data in native (reduced) dimension order.
         """
         position = self.current_scene_index
-        with self._fs.open(self._path, "rb") as f:
-            with nd2.ND2File(f) as rdr:
-                dims, shape = self._dims_and_shape_from_nd2(
-                    rdr,
-                    position,
-                )
-                shape_by_dim = dict(zip(dims, shape))
-                frame_coord_dims = nd2.AXIS.frame_coords()
-                coord_dims = [dim for dim in rdr.sizes if dim not in frame_coord_dims]
-                frame_dims = [dim for dim in given_dims if dim in frame_coord_dims]
-                current_frame_dims = [
-                    dim for dim in rdr.sizes if dim in frame_coord_dims
-                ]
+        with self._open_nd2() as rdr:
+            dims, shape = self._dims_and_shape_from_nd2(
+                rdr,
+                position,
+            )
+            shape_by_dim = dict(zip(dims, shape))
+            frame_coord_dims = nd2.AXIS.frame_coords()
+            coord_dims = [dim for dim in rdr.sizes if dim not in frame_coord_dims]
+            frame_dims = [dim for dim in given_dims if dim in frame_coord_dims]
+            current_frame_dims = [dim for dim in rdr.sizes if dim in frame_coord_dims]
 
-                selected_indices = {
-                    dim: self._indices_from_dim_spec(
-                        dim_specs[dim_index],
-                        shape_by_dim[dim],
-                    )
-                    for dim_index, dim in enumerate(given_dims)
+            selected_indices = {
+                dim: self._indices_from_dim_spec(
+                    dim_specs[dim_index],
+                    shape_by_dim[dim],
+                )
+                for dim_index, dim in enumerate(given_dims)
+            }
+            subset_shape = tuple(len(selected_indices[dim]) for dim in given_dims)
+            subset = np.empty(subset_shape, dtype=rdr.dtype)
+            local_indexer = tuple(
+                self._local_dim_spec(dim_specs[dim_index], subset_shape[dim_index])
+                for dim_index in range(len(given_dims))
+            )
+
+            if 0 in subset_shape:
+                return subset[local_indexer]
+
+            coord_choices = []
+            for dim in coord_dims:
+                if dim == nd2.AXIS.POSITION:
+                    coord_choices.append([(0, position)])
+                else:
+                    coord_choices.append(list(enumerate(selected_indices[dim])))
+
+            # Resolve every requested plane to its ND2 sequence index up front,
+            # paired with where it lands in ``subset``. ND2 stores frames on disk
+            # in sequence-index order, so reading them sorted by that index keeps
+            # disk access sequential (front-to-back): contiguous runs coalesce
+            # under OS read-ahead instead of forcing a seek per plane. The
+            # dimension-iteration order is not guaranteed to match on-disk order,
+            # so without this sort a shard's reads can bounce around the file.
+            planes = []
+            for coord_selection in product(*coord_choices):
+                coord_indexes = tuple(index for _, index in coord_selection)
+                if not coord_dims:
+                    frame_index = 0
+                else:
+                    frame_index = cast(int, rdr._seq_index_from_coords(coord_indexes))
+
+                coord_ordinals = {
+                    dim: ordinal
+                    for dim, (ordinal, _) in zip(coord_dims, coord_selection)
+                    if dim != nd2.AXIS.POSITION
                 }
-                subset_shape = tuple(len(selected_indices[dim]) for dim in given_dims)
-                subset = np.empty(subset_shape, dtype=rdr.dtype)
-                local_indexer = tuple(
-                    self._local_dim_spec(dim_specs[dim_index], subset_shape[dim_index])
-                    for dim_index in range(len(given_dims))
+                subset_index = tuple(
+                    coord_ordinals[dim] if dim in coord_ordinals else slice(None)
+                    for dim in given_dims
+                )
+                planes.append((frame_index, subset_index))
+
+            for frame_index, subset_index in sorted(planes, key=lambda p: p[0]):
+                frame = np.asarray(rdr.read_frame(frame_index))
+                frame = self._reshape_frame_to_dims(
+                    frame,
+                    current_frame_dims.copy(),
+                    frame_dims,
+                    shape_by_dim,
                 )
 
-                if 0 in subset_shape:
-                    return subset[local_indexer]
-
-                coord_choices = []
-                for dim in coord_dims:
-                    if dim == nd2.AXIS.POSITION:
-                        coord_choices.append([(0, position)])
-                    else:
-                        coord_choices.append(list(enumerate(selected_indices[dim])))
-
-                for coord_selection in product(*coord_choices):
-                    coord_indexes = tuple(index for _, index in coord_selection)
-                    if not coord_dims:
-                        frame_index = 0
-                    else:
-                        frame_index = cast(
-                            int, rdr._seq_index_from_coords(coord_indexes)
-                        )
-
-                    frame = np.asarray(rdr.read_frame(frame_index))
-                    frame = self._reshape_frame_to_dims(
+                for frame_axis, dim in enumerate(frame_dims):
+                    frame = np.take(
                         frame,
-                        current_frame_dims.copy(),
-                        frame_dims,
-                        shape_by_dim,
+                        selected_indices[dim],
+                        axis=frame_axis,
                     )
 
-                    for frame_axis, dim in enumerate(frame_dims):
-                        frame = np.take(
-                            frame,
-                            selected_indices[dim],
-                            axis=frame_axis,
-                        )
-
-                    coord_ordinals = {
-                        dim: ordinal
-                        for dim, (ordinal, _) in zip(coord_dims, coord_selection)
-                        if dim != nd2.AXIS.POSITION
-                    }
-                    subset_index = tuple(
-                        coord_ordinals[dim] if dim in coord_ordinals else slice(None)
-                        for dim in given_dims
-                    )
-                    subset[subset_index] = frame
+                subset[subset_index] = frame
 
         return subset[local_indexer]
 
@@ -466,9 +491,8 @@ class Reader(reader.Reader):
         We currently do not handle unit attachment to these values. Please see the file
         metadata for unit information.
         """
-        with self._fs.open(self._path, "rb") as f:
-            with nd2.ND2File(f) as rdr:
-                return types.PhysicalPixelSizes(*rdr.voxel_size()[::-1])
+        with self._open_nd2() as rdr:
+            return types.PhysicalPixelSizes(*rdr.voxel_size()[::-1])
 
     @property
     def binning(self) -> str | None:
@@ -478,7 +502,7 @@ class Reader(reader.Reader):
         binning : str | None
             Binning value reported by the ND2File metadata, e.g., "1x1".
         """
-        with self._fs.open(self._path, "rb") as f, nd2.ND2File(f) as rdr:
+        with self._open_nd2() as rdr:
             desc = rdr.text_info.get("description", "")
             match = re.search(r"\bBinning:\s*(\d+x\d+)", desc)
             return match.group(1) if match else None
@@ -500,9 +524,8 @@ class Reader(reader.Reader):
             No metadata transformer available.
         """
         if hasattr(nd2.ND2File, "ome_metadata"):
-            with self._fs.open(self._path, "rb") as f:
-                with nd2.ND2File(f) as rdr:
-                    return rdr.ome_metadata()
+            with self._open_nd2() as rdr:
+                return rdr.ome_metadata()
         raise NotImplementedError()
 
     def _get_scene_to_well_map(self) -> Dict[int, WellPosition | None]:
@@ -520,14 +543,13 @@ class Reader(reader.Reader):
             self._scene_to_well_map = {i: None for i in range(len(self.scenes))}
             return self._scene_to_well_map
 
-        with self._fs.open(self._path, "rb") as f:
-            with nd2.ND2File(f) as rdr:
-                wells = self._plate.generate_wells()
+        with self._open_nd2() as rdr:
+            wells = self._plate.generate_wells()
 
-                position_xy = extract_position_stage_xy_um(rdr)
-                scene_to_position = extract_scene_to_position_index(
-                    rdr, num_scenes=len(self.scenes)
-                )
+            position_xy = extract_position_stage_xy_um(rdr)
+            scene_to_position = extract_scene_to_position_index(
+                rdr, num_scenes=len(self.scenes)
+            )
 
         self._scene_to_well_map = map_scenes_to_wells(
             scene_to_position,
@@ -592,13 +614,12 @@ class Reader(reader.Reader):
             return metadata
 
         try:
-            with self._fs.open(self._path, "rb") as fh:
-                with nd2.ND2File(fh) as f:
-                    ri = f.metadata.channels[0].microscope.immersionRefractiveIndex
+            with self._open_nd2() as f:
+                ri = f.metadata.channels[0].microscope.immersionRefractiveIndex
 
-                    # 1.33 is the refractive index of water
-                    if ri is not None and abs(float(ri) - 1.333) <= 1e-3:
-                        metadata.objective = f"{metadata.objective}Water"
+                # 1.33 is the refractive index of water
+                if ri is not None and abs(float(ri) - 1.333) <= 1e-3:
+                    metadata.objective = f"{metadata.objective}Water"
 
         except Exception as err:
             log.warning(f"Failed to patch ND2 objective immersion suffix: {err}")

--- a/bioio_nd2/reader.py
+++ b/bioio_nd2/reader.py
@@ -1,10 +1,14 @@
 import logging
 import re
-from typing import Any, Dict, Tuple
+from itertools import product
+from numbers import Integral
+from typing import Any, Dict, Optional, Tuple, cast
 
 import nd2
+import numpy as np
 import xarray as xr
 from bioio_base import constants, exceptions, io, reader, types
+from bioio_base.dimensions import Dimensions
 from bioio_base.standard_metadata import StandardMetadata
 from fsspec.implementations.cached import CachingFileSystem
 from fsspec.implementations.local import LocalFileSystem
@@ -49,6 +53,10 @@ class Reader(reader.Reader):
     """
 
     _scene_to_well_map: Dict[int, WellPosition | None] | None = None
+    # must match the bioio-base Reader's signature for the `dims` property,
+    # which is cached here for mypy type checking reasons
+    _dims: Optional[Dimensions] = None
+    _dtype: Optional[np.dtype] = None
 
     @staticmethod
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
@@ -89,11 +97,339 @@ class Reader(reader.Reader):
             with nd2.ND2File(f) as rdr:
                 return tuple(rdr._position_names())
 
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        """
+        Returns
+        -------
+        shape: Tuple[int, ...]
+            Tuple of the image array's dimensions.
+        """
+        return self.dims.shape
+
+    @property
+    def dtype(self) -> np.dtype:
+        """
+        Returns
+        -------
+        dtype: np.dtype
+            Data-type of the image array's elements.
+        """
+        if self._dtype is None:
+            with self._fs.open(self._path, "rb") as f:
+                with nd2.ND2File(f) as rdr:
+                    self._dtype = rdr.dtype
+
+        return self._dtype
+
+    @property
+    def dims(self) -> Dimensions:
+        """
+        Returns
+        -------
+        dims: Dimensions
+            Object with the paired dimension names and their sizes.
+        """
+        if self._dims is None:
+            dims, shape = self._read_dims_and_shape()
+            self._dims = Dimensions(dims=dims, shape=shape)
+
+        return self._dims
+
+    def _read_dims_and_shape(self) -> Tuple[Tuple[str, ...], Tuple[int, ...]]:
+        """
+        Read the dimension names and sizes for the current scene from the ND2
+        metadata, without constructing the dask-backed xarray.
+
+        Returns
+        -------
+        dims: Tuple[str, ...]
+            The ordered dimension names for the current scene.
+        shape: Tuple[int, ...]
+            The size of each dimension, in the same order as ``dims``.
+        """
+        with self._fs.open(self._path, "rb") as f:
+            with nd2.ND2File(f) as rdr:
+                dims, shape = self._dims_and_shape_from_nd2(
+                    rdr,
+                    self.current_scene_index,
+                )
+
+        return tuple(dims), tuple(shape)
+
+    @staticmethod
+    def _dims_and_shape_from_nd2(
+        rdr: nd2.ND2File,
+        position: int | None = None,
+    ) -> Tuple[list[str], list[int]]:
+        """
+        Derive the dimension names and sizes from an open ND2 file, dropping the
+        position axis for the requested scene.
+
+        Parameters
+        ----------
+        rdr: nd2.ND2File
+            An open ND2 file to read dimension metadata from.
+        position: int | None
+            The scene (position) index to select. When the file has a position
+            axis it is removed from the returned dims/shape. Defaults to None.
+
+        Returns
+        -------
+        dims: list[str]
+            The ordered dimension names, excluding the position axis.
+        shape: list[int]
+            The size of each dimension, in the same order as ``dims``.
+
+        Raises
+        ------
+        IndexError
+            If ``position`` is out of range for the available positions.
+        """
+        dims = list(rdr.sizes)
+        shape = list(rdr.shape)
+        coords = rdr._expand_coords(squeeze=False)
+
+        for missing_dim in set(coords).difference(dims):
+            dims.insert(0, missing_dim)
+            shape.insert(0, len(coords[missing_dim]))
+
+        try:
+            position_index = dims.index(nd2.AXIS.POSITION)
+        except ValueError:
+            if position and position > 0:
+                raise IndexError(
+                    f"Position {position} is out of range. Only 1 position available"
+                )
+        else:
+            if position is not None and position >= shape[position_index]:
+                raise IndexError(
+                    f"Position {position} is out of range. "
+                    f"Only {shape[position_index]} positions available"
+                )
+
+            shape[position_index] = 1
+            dims.pop(position_index)
+            shape.pop(position_index)
+
+        return dims, shape
+
+    @staticmethod
+    def _indices_from_dim_spec(dim_spec: Any, size: int) -> list[int]:
+        """
+        Resolve a single-dimension getitem spec into the concrete list of
+        source indices it selects.
+
+        Parameters
+        ----------
+        dim_spec: Any
+            The getitem operation for one dimension (an integer, slice, range,
+            tuple, or list of integers).
+        size: int
+            The size of the dimension being indexed.
+
+        Returns
+        -------
+        indices: list[int]
+            The selected indices into the dimension.
+
+        Raises
+        ------
+        TypeError
+            If ``dim_spec`` is not a supported indexer type.
+        """
+        dim_range = range(size)
+        if isinstance(dim_spec, Integral):
+            return [dim_range[int(dim_spec)]]
+
+        if isinstance(dim_spec, slice):
+            return list(dim_range[dim_spec])
+
+        if isinstance(dim_spec, range):
+            dim_spec = list(dim_spec)
+
+        if isinstance(dim_spec, tuple):
+            dim_spec = list(dim_spec)
+
+        if isinstance(dim_spec, list):
+            return [dim_range[int(index)] for index in dim_spec]
+
+        raise TypeError(f"Unsupported dimension indexer: {type(dim_spec).__name__}")
+
+    @staticmethod
+    def _local_dim_spec(dim_spec: Any, size: int) -> Any:
+        """
+        Translate a source-dimension getitem spec into the equivalent indexer
+        for the gathered subset array, which is already reduced to the selected
+        indices.
+
+        Parameters
+        ----------
+        dim_spec: Any
+            The original getitem operation for one dimension.
+        size: int
+            The size of the dimension in the gathered subset array.
+
+        Returns
+        -------
+        local_spec: Any
+            The indexer to apply to the subset array: ``0`` for an integer
+            spec (to drop the axis), ``slice(None)`` for a slice, or the full
+            list of local indices otherwise.
+        """
+        if isinstance(dim_spec, Integral):
+            return 0
+
+        if isinstance(dim_spec, slice):
+            return slice(None)
+
+        return list(range(size))
+
+    @staticmethod
+    def _reshape_frame_to_dims(
+        frame: np.ndarray,
+        current_dims: list[str],
+        target_dims: list[str],
+        shape_by_dim: Dict[str, int],
+    ) -> np.ndarray:
+        """
+        Reshape and transpose a raw ND2 frame so its axes match the requested
+        target dimension order, inserting size-1 axes for any missing dims.
+
+        Parameters
+        ----------
+        frame: np.ndarray
+            The raw frame data as read from the ND2 file.
+        current_dims: list[str]
+            The dimension names currently present in ``frame``, in order. This
+            list is mutated in place as axes are inserted.
+        target_dims: list[str]
+            The desired dimension names, in order, for the returned frame.
+        shape_by_dim: Dict[str, int]
+            Mapping of dimension name to its size, used to reshape ``frame``.
+
+        Returns
+        -------
+        frame: np.ndarray
+            The frame reshaped and transposed to match ``target_dims``.
+        """
+        if current_dims:
+            frame = frame.reshape(tuple(shape_by_dim[dim] for dim in current_dims))
+        else:
+            frame = frame.reshape(())
+
+        for dim in target_dims:
+            if dim not in current_dims:
+                frame = np.expand_dims(frame, axis=0)
+                current_dims.insert(0, dim)
+
+        if current_dims != target_dims:
+            frame = frame.transpose([current_dims.index(dim) for dim in target_dims])
+
+        return frame
+
     def _read_delayed(self) -> xr.DataArray:
         return self._xarr_reformat(delayed=True)
 
     def _read_immediate(self) -> xr.DataArray:
         return self._xarr_reformat(delayed=False)
+
+    def _read_indexed(self, given_dims: str, dim_specs: list) -> np.ndarray:
+        """
+        Return the native-order array with ``dim_specs`` applied.
+
+        This lets ``get_image_data`` read only the requested sub-region. It reads
+        each requested frame one at a time and applies the selection, so only the
+        requested planes are read off disk.
+
+        Parameters
+        ----------
+        given_dims: str
+            The native dimension ordering of the image (``self.dims.order``).
+        dim_specs: list
+            One getitem operation per dimension in ``given_dims``, as produced by
+            ``transforms.compute_dim_specs``.
+
+        Returns
+        -------
+        data: np.ndarray
+            The indexed image data in native (reduced) dimension order.
+        """
+        position = self.current_scene_index
+        with self._fs.open(self._path, "rb") as f:
+            with nd2.ND2File(f) as rdr:
+                dims, shape = self._dims_and_shape_from_nd2(
+                    rdr,
+                    position,
+                )
+                shape_by_dim = dict(zip(dims, shape))
+                frame_coord_dims = nd2.AXIS.frame_coords()
+                coord_dims = [dim for dim in rdr.sizes if dim not in frame_coord_dims]
+                frame_dims = [dim for dim in given_dims if dim in frame_coord_dims]
+                current_frame_dims = [
+                    dim for dim in rdr.sizes if dim in frame_coord_dims
+                ]
+
+                selected_indices = {
+                    dim: self._indices_from_dim_spec(
+                        dim_specs[dim_index],
+                        shape_by_dim[dim],
+                    )
+                    for dim_index, dim in enumerate(given_dims)
+                }
+                subset_shape = tuple(len(selected_indices[dim]) for dim in given_dims)
+                subset = np.empty(subset_shape, dtype=rdr.dtype)
+                local_indexer = tuple(
+                    self._local_dim_spec(dim_specs[dim_index], subset_shape[dim_index])
+                    for dim_index in range(len(given_dims))
+                )
+
+                if 0 in subset_shape:
+                    return subset[local_indexer]
+
+                coord_choices = []
+                for dim in coord_dims:
+                    if dim == nd2.AXIS.POSITION:
+                        coord_choices.append([(0, position)])
+                    else:
+                        coord_choices.append(list(enumerate(selected_indices[dim])))
+
+                for coord_selection in product(*coord_choices):
+                    coord_indexes = tuple(index for _, index in coord_selection)
+                    if not coord_dims:
+                        frame_index = 0
+                    else:
+                        frame_index = cast(
+                            int, rdr._seq_index_from_coords(coord_indexes)
+                        )
+
+                    frame = np.asarray(rdr.read_frame(frame_index))
+                    frame = self._reshape_frame_to_dims(
+                        frame,
+                        current_frame_dims.copy(),
+                        frame_dims,
+                        shape_by_dim,
+                    )
+
+                    for frame_axis, dim in enumerate(frame_dims):
+                        frame = np.take(
+                            frame,
+                            selected_indices[dim],
+                            axis=frame_axis,
+                        )
+
+                    coord_ordinals = {
+                        dim: ordinal
+                        for dim, (ordinal, _) in zip(coord_dims, coord_selection)
+                        if dim != nd2.AXIS.POSITION
+                    }
+                    subset_index = tuple(
+                        coord_ordinals[dim] if dim in coord_ordinals else slice(None)
+                        for dim in given_dims
+                    )
+                    subset[subset_index] = frame
+
+        return subset[local_indexer]
 
     def _xarr_reformat(self, delayed: bool) -> xr.DataArray:
         with self._fs.open(self._path, "rb") as f:

--- a/bioio_nd2/reader.py
+++ b/bioio_nd2/reader.py
@@ -54,8 +54,6 @@ class Reader(reader.Reader):
     """
 
     _scene_to_well_map: Dict[int, WellPosition | None] | None = None
-    # must match the bioio-base Reader's signature for the `dims` property,
-    # which is cached here for mypy type checking reasons
     _dims: Optional[Dimensions] = None
     _dtype: Optional[np.dtype] = None
 
@@ -94,16 +92,8 @@ class Reader(reader.Reader):
 
     @contextmanager
     def _open_nd2(self) -> Iterator[nd2.ND2File]:
-        """Open the backing ND2 file, memory-mapping it when possible.
-
-        For a local filesystem the path is handed directly to ``nd2.ND2File`` so
-        the SDK memory-maps the file. Repeated ``read_frame`` calls then read
-        from OS-cached pages and benefit from kernel read-ahead, instead of
-        streaming every plane through a Python file object. Memory-mapping maps
-        the file in place and never copies it, which matters for very large ND2s
-        that cannot be staged to local disk. Remote sources (a
-        ``CachingFileSystem``) cannot be memory-mapped, so they fall back to an
-        fsspec handle.
+        """
+        Open the backing ND2 file, memory-mapping it when possible.
         """
         if isinstance(self._fs, LocalFileSystem):
             with nd2.ND2File(self._path) as rdr:

--- a/bioio_nd2/reader.py
+++ b/bioio_nd2/reader.py
@@ -148,204 +148,39 @@ class Reader(reader.Reader):
         Returns
         -------
         dims: Dimensions
-            Object with the paired dimension names and their sizes.
+            Paired dimension names and their sizes.
         """
         if self._dims is None:
-            dims, shape = self._read_dims_and_shape()
-            self._dims = Dimensions(dims=dims, shape=shape)
+            with self._open_nd2() as rdr:
+                dims = list(rdr.sizes)
+                shape = list(rdr.shape)
+                coords = rdr._expand_coords(squeeze=False)
+
+                for missing_dim in set(coords).difference(dims):
+                    dims.insert(0, missing_dim)
+                    shape.insert(0, len(coords[missing_dim]))
+
+                position = self.current_scene_index
+                try:
+                    position_index = dims.index(nd2.AXIS.POSITION)
+                except ValueError:
+                    if position and position > 0:
+                        raise IndexError(
+                            f"Position {position} is out of range. "
+                            f"Only 1 position available"
+                        )
+                else:
+                    if position is not None and position >= shape[position_index]:
+                        raise IndexError(
+                            f"Position {position} is out of range. "
+                            f"Only {shape[position_index]} positions available"
+                        )
+                    dims.pop(position_index)
+                    shape.pop(position_index)
+
+            self._dims = Dimensions(dims=tuple(dims), shape=tuple(shape))
 
         return self._dims
-
-    def _read_dims_and_shape(self) -> Tuple[Tuple[str, ...], Tuple[int, ...]]:
-        """
-        Read the dimension names and sizes for the current scene from the ND2
-        metadata, without constructing the dask-backed xarray.
-
-        Returns
-        -------
-        dims: Tuple[str, ...]
-            The ordered dimension names for the current scene.
-        shape: Tuple[int, ...]
-            The size of each dimension, in the same order as ``dims``.
-        """
-        with self._open_nd2() as rdr:
-            dims, shape = self._dims_and_shape_from_nd2(
-                rdr,
-                self.current_scene_index,
-            )
-
-        return tuple(dims), tuple(shape)
-
-    @staticmethod
-    def _dims_and_shape_from_nd2(
-        rdr: nd2.ND2File,
-        position: int | None = None,
-    ) -> Tuple[list[str], list[int]]:
-        """
-        Derive the dimension names and sizes from an open ND2 file, dropping the
-        position axis for the requested scene.
-
-        Parameters
-        ----------
-        rdr: nd2.ND2File
-            An open ND2 file to read dimension metadata from.
-        position: int | None
-            The scene (position) index to select. When the file has a position
-            axis it is removed from the returned dims/shape. Defaults to None.
-
-        Returns
-        -------
-        dims: list[str]
-            The ordered dimension names, excluding the position axis.
-        shape: list[int]
-            The size of each dimension, in the same order as ``dims``.
-
-        Raises
-        ------
-        IndexError
-            If ``position`` is out of range for the available positions.
-        """
-        dims = list(rdr.sizes)
-        shape = list(rdr.shape)
-        coords = rdr._expand_coords(squeeze=False)
-
-        for missing_dim in set(coords).difference(dims):
-            dims.insert(0, missing_dim)
-            shape.insert(0, len(coords[missing_dim]))
-
-        try:
-            position_index = dims.index(nd2.AXIS.POSITION)
-        except ValueError:
-            if position and position > 0:
-                raise IndexError(
-                    f"Position {position} is out of range. Only 1 position available"
-                )
-        else:
-            if position is not None and position >= shape[position_index]:
-                raise IndexError(
-                    f"Position {position} is out of range. "
-                    f"Only {shape[position_index]} positions available"
-                )
-
-            shape[position_index] = 1
-            dims.pop(position_index)
-            shape.pop(position_index)
-
-        return dims, shape
-
-    @staticmethod
-    def _indices_from_dim_spec(dim_spec: Any, size: int) -> list[int]:
-        """
-        Resolve a single-dimension getitem spec into the concrete list of
-        source indices it selects.
-
-        Parameters
-        ----------
-        dim_spec: Any
-            The getitem operation for one dimension (an integer, slice, range,
-            tuple, or list of integers).
-        size: int
-            The size of the dimension being indexed.
-
-        Returns
-        -------
-        indices: list[int]
-            The selected indices into the dimension.
-
-        Raises
-        ------
-        TypeError
-            If ``dim_spec`` is not a supported indexer type.
-        """
-        dim_range = range(size)
-        if isinstance(dim_spec, Integral):
-            return [dim_range[int(dim_spec)]]
-
-        if isinstance(dim_spec, slice):
-            return list(dim_range[dim_spec])
-
-        if isinstance(dim_spec, range):
-            dim_spec = list(dim_spec)
-
-        if isinstance(dim_spec, tuple):
-            dim_spec = list(dim_spec)
-
-        if isinstance(dim_spec, list):
-            return [dim_range[int(index)] for index in dim_spec]
-
-        raise TypeError(f"Unsupported dimension indexer: {type(dim_spec).__name__}")
-
-    @staticmethod
-    def _local_dim_spec(dim_spec: Any, size: int) -> Any:
-        """
-        Translate a source-dimension getitem spec into the equivalent indexer
-        for the gathered subset array, which is already reduced to the selected
-        indices.
-
-        Parameters
-        ----------
-        dim_spec: Any
-            The original getitem operation for one dimension.
-        size: int
-            The size of the dimension in the gathered subset array.
-
-        Returns
-        -------
-        local_spec: Any
-            The indexer to apply to the subset array: ``0`` for an integer
-            spec (to drop the axis), ``slice(None)`` for a slice, or the full
-            list of local indices otherwise.
-        """
-        if isinstance(dim_spec, Integral):
-            return 0
-
-        if isinstance(dim_spec, slice):
-            return slice(None)
-
-        return list(range(size))
-
-    @staticmethod
-    def _reshape_frame_to_dims(
-        frame: np.ndarray,
-        current_dims: list[str],
-        target_dims: list[str],
-        shape_by_dim: Dict[str, int],
-    ) -> np.ndarray:
-        """
-        Reshape and transpose a raw ND2 frame so its axes match the requested
-        target dimension order, inserting size-1 axes for any missing dims.
-
-        Parameters
-        ----------
-        frame: np.ndarray
-            The raw frame data as read from the ND2 file.
-        current_dims: list[str]
-            The dimension names currently present in ``frame``, in order. This
-            list is mutated in place as axes are inserted.
-        target_dims: list[str]
-            The desired dimension names, in order, for the returned frame.
-        shape_by_dim: Dict[str, int]
-            Mapping of dimension name to its size, used to reshape ``frame``.
-
-        Returns
-        -------
-        frame: np.ndarray
-            The frame reshaped and transposed to match ``target_dims``.
-        """
-        if current_dims:
-            frame = frame.reshape(tuple(shape_by_dim[dim] for dim in current_dims))
-        else:
-            frame = frame.reshape(())
-
-        for dim in target_dims:
-            if dim not in current_dims:
-                frame = np.expand_dims(frame, axis=0)
-                current_dims.insert(0, dim)
-
-        if current_dims != target_dims:
-            frame = frame.transpose([current_dims.index(dim) for dim in target_dims])
-
-        return frame
 
     def _read_delayed(self) -> xr.DataArray:
         return self._xarr_reformat(delayed=True)
@@ -375,29 +210,23 @@ class Reader(reader.Reader):
             The indexed image data in native (reduced) dimension order.
         """
         position = self.current_scene_index
+        shape_by_dim = dict(zip(self.dims.order, self.dims.shape))
         with self._open_nd2() as rdr:
-            dims, shape = self._dims_and_shape_from_nd2(
-                rdr,
-                position,
-            )
-            shape_by_dim = dict(zip(dims, shape))
+            # nd2 splits dims into per-frame axes (C/Y/X/S, returned by
+            # read_frame) and loop axes (P/T/Z, addressed by sequence index).
             frame_coord_dims = nd2.AXIS.frame_coords()
             coord_dims = [dim for dim in rdr.sizes if dim not in frame_coord_dims]
             frame_dims = [dim for dim in given_dims if dim in frame_coord_dims]
-            current_frame_dims = [dim for dim in rdr.sizes if dim in frame_coord_dims]
 
+            # Source indices each spec selects
             selected_indices = {
-                dim: self._indices_from_dim_spec(
-                    dim_specs[dim_index],
-                    shape_by_dim[dim],
-                )
-                for dim_index, dim in enumerate(given_dims)
+                dim: np.atleast_1d(np.arange(shape_by_dim[dim])[spec]).tolist()
+                for dim, spec in zip(given_dims, dim_specs)
             }
             subset_shape = tuple(len(selected_indices[dim]) for dim in given_dims)
             subset = np.empty(subset_shape, dtype=rdr.dtype)
             local_indexer = tuple(
-                self._local_dim_spec(dim_specs[dim_index], subset_shape[dim_index])
-                for dim_index in range(len(given_dims))
+                0 if isinstance(spec, Integral) else slice(None) for spec in dim_specs
             )
 
             if 0 in subset_shape:
@@ -410,13 +239,8 @@ class Reader(reader.Reader):
                 else:
                     coord_choices.append(list(enumerate(selected_indices[dim])))
 
-            # Resolve every requested plane to its ND2 sequence index up front,
-            # paired with where it lands in ``subset``. ND2 stores frames on disk
-            # in sequence-index order, so reading them sorted by that index keeps
-            # disk access sequential (front-to-back): contiguous runs coalesce
-            # under OS read-ahead instead of forcing a seek per plane. The
-            # dimension-iteration order is not guaranteed to match on-disk order,
-            # so without this sort a shard's reads can bounce around the file.
+            # Map each requested plane to its (sequence index, destination in
+            # subset).
             planes = []
             for coord_selection in product(*coord_choices):
                 coord_indexes = tuple(index for _, index in coord_selection)
@@ -437,12 +261,10 @@ class Reader(reader.Reader):
                 planes.append((frame_index, subset_index))
 
             for frame_index, subset_index in sorted(planes, key=lambda p: p[0]):
-                frame = np.asarray(rdr.read_frame(frame_index))
-                frame = self._reshape_frame_to_dims(
-                    frame,
-                    current_frame_dims.copy(),
-                    frame_dims,
-                    shape_by_dim,
+                # reshape prepends size-1 axes for any singleton frame dims
+                # missing from read_frame's output.
+                frame = np.asarray(rdr.read_frame(frame_index)).reshape(
+                    tuple(shape_by_dim[dim] for dim in frame_dims)
                 )
 
                 for frame_axis, dim in enumerate(frame_dims):

--- a/bioio_nd2/tests/test_reader.py
+++ b/bioio_nd2/tests/test_reader.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from contextlib import nullcontext
 from typing import Any, List, Tuple, Union
 
 import numpy as np
 import pytest
-import xarray as xr
 from bioio_base import exceptions, test_utilities
 from ome_types import OME
 
@@ -220,404 +218,111 @@ def test_frame_metadata(cache: bool) -> None:
     )
 
 
-def test_read_indexed_reads_only_requested_nd2_frames(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    data = np.arange(2 * 2 * 3 * 4 * 5).reshape(2, 2, 3, 4, 5)
-    frame_reads = []
+def _count_frame_reads(
+    monkeypatch: pytest.MonkeyPatch, work: Any
+) -> Tuple[Any, int]:
+    """Run ``work()`` while counting real ``nd2.ND2File.read_frame`` calls."""
+    reads = 0
+    original = nd2.ND2File.read_frame
 
-    class FakeND2File:
-        sizes = {"P": 2, "T": 2, "C": 3, "Y": 4, "X": 5}
-        shape = (2, 2, 3, 4, 5)
-        dtype = data.dtype
+    def counting_read_frame(self: Any, frame_index: int) -> Any:
+        nonlocal reads
+        reads += 1
+        return original(self, frame_index)
 
-        def __init__(self, file: object) -> None:
-            pass
-
-        def __enter__(self) -> "FakeND2File":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-        def _expand_coords(self, squeeze: bool = True) -> dict[str, object]:
-            assert squeeze is False
-            return {
-                nd2.AXIS.POSITION: range(2),
-                "T": range(2),
-                "C": range(3),
-                "Y": range(4),
-                "X": range(5),
-            }
-
-        def _seq_index_from_coords(self, coords: Tuple[int, ...]) -> int:
-            return int(np.ravel_multi_index(coords, (2, 2)))
-
-        def read_frame(self, frame_index: int) -> np.ndarray:
-            frame_reads.append(frame_index)
-            return data.reshape(4, 3, 4, 5)[frame_index]
-
-    class FakeFS:
-        def open(self, path: str, mode: str) -> Any:
-            return nullcontext(object())
-
-    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
-
-    rdr = Reader.__new__(Reader)
-    rdr._fs = FakeFS()
-    rdr._path = "example.nd2"
-    rdr._dims = None
-    rdr._current_scene_index = 1
-
-    def fail_delayed_read() -> xr.DataArray:
-        raise AssertionError("_read_delayed should not be used for indexed reads")
-
-    monkeypatch.setattr(rdr, "_read_delayed", fail_delayed_read)
-
-    actual = rdr._read_indexed(
-        "TCYX",
-        [
-            slice(None),
-            slice(1, 3),
-            slice(1, 4),
-            slice(0, 5, 2),
-        ],
-    )
-
-    np.testing.assert_array_equal(
-        actual,
-        data[1, :, 1:3, 1:4, 0:5:2],
-    )
-    assert frame_reads == [2, 3]
-
-    frame_reads.clear()
-    dim_specs = [
-        slice(None),
-        [0, 2],
-        [1, 3],
-        slice(0, 5, 2),
-    ]
-    actual = rdr._read_indexed("TCYX", dim_specs)
-
-    np.testing.assert_array_equal(
-        actual,
-        data[1][tuple(dim_specs)],
-    )
-    assert frame_reads == [2, 3]
-
-    frame_reads.clear()
-    rdr._current_scene_index = 0
-    actual = rdr._read_indexed(
-        "TCYX",
-        [
-            slice(None),
-            slice(1, 3),
-            slice(1, 4),
-            slice(0, 5, 2),
-        ],
-    )
-
-    np.testing.assert_array_equal(
-        actual,
-        data[0, :, 1:3, 1:4, 0:5:2],
-    )
-    assert frame_reads == [0, 1]
-
-    rdr._current_scene_index = 2
-    with pytest.raises(IndexError, match="Position 2 is out of range"):
-        rdr._read_indexed("TCYX", dim_specs)
+    monkeypatch.setattr(nd2.ND2File, "read_frame", counting_read_frame)
+    result = work()
+    return result, reads
 
 
-def test_read_indexed_reads_single_middle_plane(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    data = np.arange(3 * 5 * 7 * 4 * 6 * 8).reshape(3, 5, 7, 4, 6, 8)
-    frame_reads = []
-
-    class FakeND2File:
-        sizes = {
-            nd2.AXIS.POSITION: 3,
-            "T": 5,
-            "Z": 7,
-            "C": 4,
-            "Y": 6,
-            "X": 8,
-        }
-        shape = (3, 5, 7, 4, 6, 8)
-        dtype = data.dtype
-
-        def __init__(self, file: object) -> None:
-            pass
-
-        def __enter__(self) -> "FakeND2File":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-        def _expand_coords(self, squeeze: bool = True) -> dict[str, object]:
-            assert squeeze is False
-            return {
-                nd2.AXIS.POSITION: range(3),
-                "T": range(5),
-                "Z": range(7),
-                "C": range(4),
-                "Y": range(6),
-                "X": range(8),
-            }
-
-        def _seq_index_from_coords(self, coords: Tuple[int, ...]) -> int:
-            return int(np.ravel_multi_index(coords, (3, 5, 7)))
-
-        def read_frame(self, frame_index: int) -> np.ndarray:
-            frame_reads.append(frame_index)
-            return data.reshape(3 * 5 * 7, 4, 6, 8)[frame_index]
-
-    class FakeFS:
-        def open(self, path: str, mode: str) -> Any:
-            return nullcontext(object())
-
-    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
-
-    rdr = Reader.__new__(Reader)
-    rdr._fs = FakeFS()
-    rdr._path = "example.nd2"
-    rdr._dims = None
-    rdr._current_scene_index = 1
-
-    actual = rdr._read_indexed(
-        "TZCYX",
-        [
+@pytest.mark.parametrize(
+    "filename, set_scene, dimension_order_out, kwargs",
+    [
+        # Simplest case: single channel selection.
+        ("ND2_dims_c2y32x32.nd2", 0, "YX", {"C": 1}),
+        # Single-plane collapse across two dims.
+        ("ND2_dims_p4z5t3c2y32x32.nd2", 1, "ZYX", {"T": 1, "C": 0}),
+        # Slices with a step + fancy indexing together, on a non-zero scene.
+        (
+            "ND2_dims_p4z5t3c2y32x32.nd2",
             2,
-            3,
-            2,
-            slice(None),
-            slice(None),
-        ],
-    )
-
-    np.testing.assert_array_equal(actual, data[1, 2, 3, 2])
-    assert frame_reads == [int(np.ravel_multi_index((1, 2, 3), (3, 5, 7)))]
-
-
-def test_dims_and_shape_use_nd2_metadata_without_xarray_dask_data(
+            "TZCYX",
+            {"T": slice(0, 2), "C": [0, 1], "Z": slice(0, 5, 2)},
+        ),
+        # Dimension not present in the file (T) is added with depth 1.
+        ("ND2_dims_c2y32x32.nd2", 0, "TCYX", {}),
+        # RGB file: the trailing sample (S) axis must survive the round trip.
+        ("ND2_dims_rgb_t3p2c2z3x64y64.nd2", 1, "ZCYXS", {"T": 0}),
+    ],
+)
+def test_indexed_read_matches_full_read(
+    filename: str,
+    set_scene: int,
+    dimension_order_out: str,
+    kwargs: dict,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    class FakeND2File:
-        sizes = {nd2.AXIS.POSITION: 3, "Y": 4, "X": 5}
-        shape = (3, 4, 5)
+    """
+    The optimized indexed read must return exactly the same pixels as the
+    naive "read the whole scene, then slice" path it replaces.
+    """
+    uri = LOCAL_RESOURCES_DIR / filename
 
-        def __init__(self, file: object) -> None:
-            pass
+    optimized = Reader(uri)
+    optimized.set_scene(set_scene)
+    actual = optimized.get_image_data(dimension_order_out, **kwargs)
 
-        def __enter__(self) -> "FakeND2File":
-            return self
+    # Reference: fall back to the base-class behavior (materialize, then index).
+    reference = Reader(uri)
+    reference.set_scene(set_scene)
+    monkeypatch.setattr(
+        reference,
+        "_read_indexed",
+        lambda _given_dims, dim_specs: reference.data[tuple(dim_specs)],
+    )
+    expected = reference.get_image_data(dimension_order_out, **kwargs)
 
-        def __exit__(self, *args: object) -> None:
-            pass
+    np.testing.assert_array_equal(actual, expected)
 
-        def _expand_coords(self, squeeze: bool = True) -> dict[str, object]:
-            assert squeeze is False
-            return {
-                nd2.AXIS.POSITION: range(3),
-                "Y": range(4),
-                "X": range(5),
-                "C": ["channel"],
-            }
 
-    class FakeFS:
-        def __init__(self) -> None:
-            self.open_count = 0
+def test_indexed_read_only_reads_requested_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An indexed read should pull only the requested planes off disk."""
+    uri = LOCAL_RESOURCES_DIR / "ND2_dims_p4z5t3c2y32x32.nd2"
 
-        def open(self, path: str, mode: str) -> Any:
-            self.open_count += 1
-            return nullcontext(object())
+    rdr = Reader(uri)
+    rdr.set_scene(1)
 
-    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
+    # Selecting one T and one C leaves only the 5 Z planes to read, far fewer
+    # than the 3 * 5 * 2 = 30 frames in the full scene.
+    _, reads = _count_frame_reads(
+        monkeypatch, lambda: rdr.get_image_data("ZYX", T=1, C=0)
+    )
+    assert reads == 5
 
-    fs = FakeFS()
-    rdr = Reader.__new__(Reader)
-    rdr._fs = fs
-    rdr._path = "example.nd2"
-    rdr._dims = None
-    rdr._current_scene_index = 2
 
-    def fail_delayed_read() -> xr.DataArray:
-        raise AssertionError("_read_delayed should not be used for dims or shape")
+def test_metadata_served_without_reading_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``dims``/``shape``/``dtype`` come from metadata, reading no pixel data."""
+    uri = LOCAL_RESOURCES_DIR / "ND2_dims_p4z5t3c2y32x32.nd2"
 
-    monkeypatch.setattr(rdr, "_read_delayed", fail_delayed_read)
+    def read_metadata() -> None:
+        rdr = Reader(uri)
+        rdr.set_scene(1)
+        _ = rdr.dims
+        _ = rdr.shape
+        _ = rdr.dtype
 
-    assert rdr.dims.order == "CYX"
-    assert rdr.shape == (1, 4, 5)
-    assert fs.open_count == 1
+    _, reads = _count_frame_reads(monkeypatch, read_metadata)
+    assert reads == 0
 
-    rdr._dims = None
-    rdr._current_scene_index = 3
-    with pytest.raises(IndexError, match="Position 3 is out of range"):
+
+def test_position_out_of_range_raises() -> None:
+    """Selecting a scene index beyond the available positions is an error."""
+    uri = LOCAL_RESOURCES_DIR / "ND2_dims_p4z5t3c2y32x32.nd2"
+    rdr = Reader(uri)
+    rdr._current_scene_index = 99
+    with pytest.raises(IndexError, match="out of range"):
         rdr.dims
-
-
-def test_dtype_uses_nd2_metadata_without_xarray_dask_data(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class FakeND2File:
-        dtype = np.dtype("uint16")
-
-        def __init__(self, file: object) -> None:
-            pass
-
-        def __enter__(self) -> "FakeND2File":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-    class FakeFS:
-        def __init__(self) -> None:
-            self.open_count = 0
-
-        def open(self, path: str, mode: str) -> Any:
-            self.open_count += 1
-            return nullcontext(object())
-
-    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
-
-    fs = FakeFS()
-    rdr = Reader.__new__(Reader)
-    rdr._fs = fs
-    rdr._path = "example.nd2"
-    rdr._dtype = None
-
-    def fail_delayed_read() -> xr.DataArray:
-        raise AssertionError("_read_delayed should not be used for dtype")
-
-    monkeypatch.setattr(rdr, "_read_delayed", fail_delayed_read)
-
-    assert rdr.dtype == np.dtype("uint16")
-    assert fs.open_count == 1
-
-    # repeated access is served from the cache without reopening the file
-    assert rdr.dtype == np.dtype("uint16")
-    assert fs.open_count == 1
-
-
-def test_open_nd2_memory_maps_local_path(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # On a local filesystem the path is handed straight to nd2 so it can
-    # memory-map the file (no streaming through / copying via a file handle).
-    from fsspec.implementations.local import LocalFileSystem
-
-    opened_with = []
-
-    class FakeND2File:
-        def __init__(self, file: object) -> None:
-            opened_with.append(file)
-
-        def __enter__(self) -> "FakeND2File":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
-
-    rdr = Reader.__new__(Reader)
-    rdr._fs = LocalFileSystem()
-    rdr._path = "example.nd2"
-
-    with rdr._open_nd2():
-        pass
-
-    # The raw path, not an opened file object.
-    assert opened_with == ["example.nd2"]
-
-
-def test_open_nd2_uses_handle_for_non_local_fs(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # A caching/remote filesystem cannot be memory-mapped, so the reader falls
-    # back to an fsspec handle instead of handing nd2 the path.
-    handle = object()
-    opened_with = []
-
-    class FakeND2File:
-        def __init__(self, file: object) -> None:
-            opened_with.append(file)
-
-        def __enter__(self) -> "FakeND2File":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-    class FakeCachingFS:
-        def open(self, path: str, mode: str) -> Any:
-            return nullcontext(handle)
-
-    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
-
-    rdr = Reader.__new__(Reader)
-    rdr._fs = FakeCachingFS()
-    rdr._path = "s3://bucket/example.nd2"
-
-    with rdr._open_nd2():
-        pass
-
-    # The fsspec handle, not the path.
-    assert opened_with == [handle]
-
-
-def test_read_indexed_reads_frames_in_ascending_disk_order(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # ND2 stores frames by sequence index, so _read_indexed should read them in
-    # ascending sequence order (sequential on disk) regardless of the order the
-    # requested coordinates are iterated in. Here the sequence index runs
-    # opposite to the T iteration order, so an unsorted read would seek
-    # backwards through the file.
-    data = np.arange(3 * 2 * 2).reshape(3, 2, 2)
-    frame_reads = []
-
-    class FakeND2File:
-        sizes = {"T": 3, "Y": 2, "X": 2}
-        shape = (3, 2, 2)
-        dtype = data.dtype
-
-        def __init__(self, file: object) -> None:
-            pass
-
-        def __enter__(self) -> "FakeND2File":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-        def _expand_coords(self, squeeze: bool = True) -> dict[str, object]:
-            return {"T": range(3), "Y": range(2), "X": range(2)}
-
-        def _seq_index_from_coords(self, coords: Tuple[int, ...]) -> int:
-            # Reverse the mapping: T=0 is the last frame on disk, T=2 the first.
-            return 2 - coords[0]
-
-        def read_frame(self, frame_index: int) -> np.ndarray:
-            frame_reads.append(frame_index)
-            return data[2 - frame_index]
-
-    class FakeFS:
-        def open(self, path: str, mode: str) -> Any:
-            return nullcontext(object())
-
-    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
-
-    rdr = Reader.__new__(Reader)
-    rdr._fs = FakeFS()
-    rdr._path = "example.nd2"
-    rdr._dims = None
-    rdr._current_scene_index = 0
-
-    actual = rdr._read_indexed("TYX", [slice(None), slice(None), slice(None)])
-
-    np.testing.assert_array_equal(actual, data)
-    # Frames were read front-to-back, not in the reversed iteration order.
-    assert frame_reads == [0, 1, 2]

--- a/bioio_nd2/tests/test_reader.py
+++ b/bioio_nd2/tests/test_reader.py
@@ -217,51 +217,46 @@ def test_frame_metadata(cache: bool) -> None:
         rdr.xarray_data.attrs["unprocessed"]["frame"], nd2.structures.FrameMetadata
     )
 
+
 @pytest.mark.parametrize(
-    "filename, set_scene, dimension_order_out, kwargs",
+    "filename, set_scene, dim_specs",
     [
-        # Simplest case: single channel selection.
-        ("ND2_dims_c2y32x32.nd2", 0, "YX", {"C": 1}),
-        # Single-plane collapse across two dims.
-        ("ND2_dims_p4z5t3c2y32x32.nd2", 1, "ZYX", {"T": 1, "C": 0}),
+        # Single channel selection (drops the C axis).
+        ("ND2_dims_c2y32x32.nd2", 0, [1, slice(None), slice(None)]),
+        # Single-plane collapse across two dims (native order TZCYX).
+        (
+            "ND2_dims_p4z5t3c2y32x32.nd2",
+            1,
+            [1, 0, slice(None), slice(None), slice(None)],
+        ),
         # Slices with a step + fancy indexing together, on a non-zero scene.
         (
             "ND2_dims_p4z5t3c2y32x32.nd2",
             2,
-            "TZCYX",
-            {"T": slice(0, 2), "C": [0, 1], "Z": slice(0, 5, 2)},
+            [slice(0, 2), slice(0, 5, 2), [0, 1], slice(None), slice(None)],
         ),
-        # Dimension not present in the file (T) is added with depth 1.
-        ("ND2_dims_c2y32x32.nd2", 0, "TCYX", {}),
-        # RGB file: the trailing sample (S) axis must survive the round trip.
-        ("ND2_dims_rgb_t3p2c2z3x64y64.nd2", 1, "ZCYXS", {"T": 0}),
+        # RGB file (native order TZCYXS): the trailing sample axis must survive.
+        (
+            "ND2_dims_rgb_t3p2c2z3x64y64.nd2",
+            1,
+            [0, slice(None), slice(None), slice(None), slice(None), slice(None)],
+        ),
     ],
 )
 def test_indexed_read_matches_full_read(
     filename: str,
     set_scene: int,
-    dimension_order_out: str,
-    kwargs: dict,
-    monkeypatch: pytest.MonkeyPatch,
+    dim_specs: list,
 ) -> None:
     """
-    The optimized indexed read must return exactly the same pixels as the
-    naive "read the whole scene, then slice" path it replaces.
+    Checks that slice read matches full data slice 
     """
     uri = LOCAL_RESOURCES_DIR / filename
 
-    optimized = Reader(uri)
-    optimized.set_scene(set_scene)
-    actual = optimized.get_image_data(dimension_order_out, **kwargs)
+    reader = Reader(uri)
+    reader.set_scene(set_scene)
 
-    # Reference: fall back to the base-class behavior (materialize, then index).
-    reference = Reader(uri)
-    reference.set_scene(set_scene)
-    monkeypatch.setattr(
-        reference,
-        "_read_indexed",
-        lambda _given_dims, dim_specs: reference.data[tuple(dim_specs)],
-    )
-    expected = reference.get_image_data(dimension_order_out, **kwargs)
+    expected = reader.data[tuple(dim_specs)]
+    actual = reader._read_indexed(reader.dims.order, dim_specs)
 
     np.testing.assert_array_equal(actual, expected)

--- a/bioio_nd2/tests/test_reader.py
+++ b/bioio_nd2/tests/test_reader.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from contextlib import nullcontext
 from typing import Any, List, Tuple, Union
 
 import numpy as np
 import pytest
+import xarray as xr
 from bioio_base import exceptions, test_utilities
 from ome_types import OME
 
@@ -216,3 +218,284 @@ def test_frame_metadata(cache: bool) -> None:
     assert isinstance(
         rdr.xarray_data.attrs["unprocessed"]["frame"], nd2.structures.FrameMetadata
     )
+
+
+def test_read_indexed_reads_only_requested_nd2_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = np.arange(2 * 2 * 3 * 4 * 5).reshape(2, 2, 3, 4, 5)
+    frame_reads = []
+
+    class FakeND2File:
+        sizes = {"P": 2, "T": 2, "C": 3, "Y": 4, "X": 5}
+        shape = (2, 2, 3, 4, 5)
+        dtype = data.dtype
+
+        def __init__(self, file: object) -> None:
+            pass
+
+        def __enter__(self) -> "FakeND2File":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def _expand_coords(self, squeeze: bool = True) -> dict[str, object]:
+            assert squeeze is False
+            return {
+                nd2.AXIS.POSITION: range(2),
+                "T": range(2),
+                "C": range(3),
+                "Y": range(4),
+                "X": range(5),
+            }
+
+        def _seq_index_from_coords(self, coords: Tuple[int, ...]) -> int:
+            return int(np.ravel_multi_index(coords, (2, 2)))
+
+        def read_frame(self, frame_index: int) -> np.ndarray:
+            frame_reads.append(frame_index)
+            return data.reshape(4, 3, 4, 5)[frame_index]
+
+    class FakeFS:
+        def open(self, path: str, mode: str) -> Any:
+            return nullcontext(object())
+
+    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
+
+    rdr = Reader.__new__(Reader)
+    rdr._fs = FakeFS()
+    rdr._path = "example.nd2"
+    rdr._dims = None
+    rdr._current_scene_index = 1
+
+    def fail_delayed_read() -> xr.DataArray:
+        raise AssertionError("_read_delayed should not be used for indexed reads")
+
+    monkeypatch.setattr(rdr, "_read_delayed", fail_delayed_read)
+
+    actual = rdr._read_indexed(
+        "TCYX",
+        [
+            slice(None),
+            slice(1, 3),
+            slice(1, 4),
+            slice(0, 5, 2),
+        ],
+    )
+
+    np.testing.assert_array_equal(
+        actual,
+        data[1, :, 1:3, 1:4, 0:5:2],
+    )
+    assert frame_reads == [2, 3]
+
+    frame_reads.clear()
+    dim_specs = [
+        slice(None),
+        [0, 2],
+        [1, 3],
+        slice(0, 5, 2),
+    ]
+    actual = rdr._read_indexed("TCYX", dim_specs)
+
+    np.testing.assert_array_equal(
+        actual,
+        data[1][tuple(dim_specs)],
+    )
+    assert frame_reads == [2, 3]
+
+    frame_reads.clear()
+    rdr._current_scene_index = 0
+    actual = rdr._read_indexed(
+        "TCYX",
+        [
+            slice(None),
+            slice(1, 3),
+            slice(1, 4),
+            slice(0, 5, 2),
+        ],
+    )
+
+    np.testing.assert_array_equal(
+        actual,
+        data[0, :, 1:3, 1:4, 0:5:2],
+    )
+    assert frame_reads == [0, 1]
+
+    rdr._current_scene_index = 2
+    with pytest.raises(IndexError, match="Position 2 is out of range"):
+        rdr._read_indexed("TCYX", dim_specs)
+
+
+def test_read_indexed_reads_single_middle_plane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = np.arange(3 * 5 * 7 * 4 * 6 * 8).reshape(3, 5, 7, 4, 6, 8)
+    frame_reads = []
+
+    class FakeND2File:
+        sizes = {
+            nd2.AXIS.POSITION: 3,
+            "T": 5,
+            "Z": 7,
+            "C": 4,
+            "Y": 6,
+            "X": 8,
+        }
+        shape = (3, 5, 7, 4, 6, 8)
+        dtype = data.dtype
+
+        def __init__(self, file: object) -> None:
+            pass
+
+        def __enter__(self) -> "FakeND2File":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def _expand_coords(self, squeeze: bool = True) -> dict[str, object]:
+            assert squeeze is False
+            return {
+                nd2.AXIS.POSITION: range(3),
+                "T": range(5),
+                "Z": range(7),
+                "C": range(4),
+                "Y": range(6),
+                "X": range(8),
+            }
+
+        def _seq_index_from_coords(self, coords: Tuple[int, ...]) -> int:
+            return int(np.ravel_multi_index(coords, (3, 5, 7)))
+
+        def read_frame(self, frame_index: int) -> np.ndarray:
+            frame_reads.append(frame_index)
+            return data.reshape(3 * 5 * 7, 4, 6, 8)[frame_index]
+
+    class FakeFS:
+        def open(self, path: str, mode: str) -> Any:
+            return nullcontext(object())
+
+    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
+
+    rdr = Reader.__new__(Reader)
+    rdr._fs = FakeFS()
+    rdr._path = "example.nd2"
+    rdr._dims = None
+    rdr._current_scene_index = 1
+
+    actual = rdr._read_indexed(
+        "TZCYX",
+        [
+            2,
+            3,
+            2,
+            slice(None),
+            slice(None),
+        ],
+    )
+
+    np.testing.assert_array_equal(actual, data[1, 2, 3, 2])
+    assert frame_reads == [int(np.ravel_multi_index((1, 2, 3), (3, 5, 7)))]
+
+
+def test_dims_and_shape_use_nd2_metadata_without_xarray_dask_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeND2File:
+        sizes = {nd2.AXIS.POSITION: 3, "Y": 4, "X": 5}
+        shape = (3, 4, 5)
+
+        def __init__(self, file: object) -> None:
+            pass
+
+        def __enter__(self) -> "FakeND2File":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def _expand_coords(self, squeeze: bool = True) -> dict[str, object]:
+            assert squeeze is False
+            return {
+                nd2.AXIS.POSITION: range(3),
+                "Y": range(4),
+                "X": range(5),
+                "C": ["channel"],
+            }
+
+    class FakeFS:
+        def __init__(self) -> None:
+            self.open_count = 0
+
+        def open(self, path: str, mode: str) -> Any:
+            self.open_count += 1
+            return nullcontext(object())
+
+    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
+
+    fs = FakeFS()
+    rdr = Reader.__new__(Reader)
+    rdr._fs = fs
+    rdr._path = "example.nd2"
+    rdr._dims = None
+    rdr._current_scene_index = 2
+
+    def fail_delayed_read() -> xr.DataArray:
+        raise AssertionError("_read_delayed should not be used for dims or shape")
+
+    monkeypatch.setattr(rdr, "_read_delayed", fail_delayed_read)
+
+    assert rdr.dims.order == "CYX"
+    assert rdr.shape == (1, 4, 5)
+    assert fs.open_count == 1
+
+    rdr._dims = None
+    rdr._current_scene_index = 3
+    with pytest.raises(IndexError, match="Position 3 is out of range"):
+        rdr.dims
+
+
+def test_dtype_uses_nd2_metadata_without_xarray_dask_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeND2File:
+        dtype = np.dtype("uint16")
+
+        def __init__(self, file: object) -> None:
+            pass
+
+        def __enter__(self) -> "FakeND2File":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+    class FakeFS:
+        def __init__(self) -> None:
+            self.open_count = 0
+
+        def open(self, path: str, mode: str) -> Any:
+            self.open_count += 1
+            return nullcontext(object())
+
+    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
+
+    fs = FakeFS()
+    rdr = Reader.__new__(Reader)
+    rdr._fs = fs
+    rdr._path = "example.nd2"
+    rdr._dtype = None
+
+    def fail_delayed_read() -> xr.DataArray:
+        raise AssertionError("_read_delayed should not be used for dtype")
+
+    monkeypatch.setattr(rdr, "_read_delayed", fail_delayed_read)
+
+    assert rdr.dtype == np.dtype("uint16")
+    assert fs.open_count == 1
+
+    # repeated access is served from the cache without reopening the file
+    assert rdr.dtype == np.dtype("uint16")
+    assert fs.open_count == 1

--- a/bioio_nd2/tests/test_reader.py
+++ b/bioio_nd2/tests/test_reader.py
@@ -249,7 +249,7 @@ def test_indexed_read_matches_full_read(
     dim_specs: list,
 ) -> None:
     """
-    Checks that slice read matches full data slice 
+    Checks that slice read matches full data slice
     """
     uri = LOCAL_RESOURCES_DIR / filename
 

--- a/bioio_nd2/tests/test_reader.py
+++ b/bioio_nd2/tests/test_reader.py
@@ -499,3 +499,125 @@ def test_dtype_uses_nd2_metadata_without_xarray_dask_data(
     # repeated access is served from the cache without reopening the file
     assert rdr.dtype == np.dtype("uint16")
     assert fs.open_count == 1
+
+
+def test_open_nd2_memory_maps_local_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # On a local filesystem the path is handed straight to nd2 so it can
+    # memory-map the file (no streaming through / copying via a file handle).
+    from fsspec.implementations.local import LocalFileSystem
+
+    opened_with = []
+
+    class FakeND2File:
+        def __init__(self, file: object) -> None:
+            opened_with.append(file)
+
+        def __enter__(self) -> "FakeND2File":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
+
+    rdr = Reader.__new__(Reader)
+    rdr._fs = LocalFileSystem()
+    rdr._path = "example.nd2"
+
+    with rdr._open_nd2():
+        pass
+
+    # The raw path, not an opened file object.
+    assert opened_with == ["example.nd2"]
+
+
+def test_open_nd2_uses_handle_for_non_local_fs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A caching/remote filesystem cannot be memory-mapped, so the reader falls
+    # back to an fsspec handle instead of handing nd2 the path.
+    handle = object()
+    opened_with = []
+
+    class FakeND2File:
+        def __init__(self, file: object) -> None:
+            opened_with.append(file)
+
+        def __enter__(self) -> "FakeND2File":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+    class FakeCachingFS:
+        def open(self, path: str, mode: str) -> Any:
+            return nullcontext(handle)
+
+    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
+
+    rdr = Reader.__new__(Reader)
+    rdr._fs = FakeCachingFS()
+    rdr._path = "s3://bucket/example.nd2"
+
+    with rdr._open_nd2():
+        pass
+
+    # The fsspec handle, not the path.
+    assert opened_with == [handle]
+
+
+def test_read_indexed_reads_frames_in_ascending_disk_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ND2 stores frames by sequence index, so _read_indexed should read them in
+    # ascending sequence order (sequential on disk) regardless of the order the
+    # requested coordinates are iterated in. Here the sequence index runs
+    # opposite to the T iteration order, so an unsorted read would seek
+    # backwards through the file.
+    data = np.arange(3 * 2 * 2).reshape(3, 2, 2)
+    frame_reads = []
+
+    class FakeND2File:
+        sizes = {"T": 3, "Y": 2, "X": 2}
+        shape = (3, 2, 2)
+        dtype = data.dtype
+
+        def __init__(self, file: object) -> None:
+            pass
+
+        def __enter__(self) -> "FakeND2File":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def _expand_coords(self, squeeze: bool = True) -> dict[str, object]:
+            return {"T": range(3), "Y": range(2), "X": range(2)}
+
+        def _seq_index_from_coords(self, coords: Tuple[int, ...]) -> int:
+            # Reverse the mapping: T=0 is the last frame on disk, T=2 the first.
+            return 2 - coords[0]
+
+        def read_frame(self, frame_index: int) -> np.ndarray:
+            frame_reads.append(frame_index)
+            return data[2 - frame_index]
+
+    class FakeFS:
+        def open(self, path: str, mode: str) -> Any:
+            return nullcontext(object())
+
+    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
+
+    rdr = Reader.__new__(Reader)
+    rdr._fs = FakeFS()
+    rdr._path = "example.nd2"
+    rdr._dims = None
+    rdr._current_scene_index = 0
+
+    actual = rdr._read_indexed("TYX", [slice(None), slice(None), slice(None)])
+
+    np.testing.assert_array_equal(actual, data)
+    # Frames were read front-to-back, not in the reversed iteration order.
+    assert frame_reads == [0, 1, 2]

--- a/bioio_nd2/tests/test_reader.py
+++ b/bioio_nd2/tests/test_reader.py
@@ -217,24 +217,6 @@ def test_frame_metadata(cache: bool) -> None:
         rdr.xarray_data.attrs["unprocessed"]["frame"], nd2.structures.FrameMetadata
     )
 
-
-def _count_frame_reads(
-    monkeypatch: pytest.MonkeyPatch, work: Any
-) -> Tuple[Any, int]:
-    """Run ``work()`` while counting real ``nd2.ND2File.read_frame`` calls."""
-    reads = 0
-    original = nd2.ND2File.read_frame
-
-    def counting_read_frame(self: Any, frame_index: int) -> Any:
-        nonlocal reads
-        reads += 1
-        return original(self, frame_index)
-
-    monkeypatch.setattr(nd2.ND2File, "read_frame", counting_read_frame)
-    result = work()
-    return result, reads
-
-
 @pytest.mark.parametrize(
     "filename, set_scene, dimension_order_out, kwargs",
     [
@@ -283,46 +265,3 @@ def test_indexed_read_matches_full_read(
     expected = reference.get_image_data(dimension_order_out, **kwargs)
 
     np.testing.assert_array_equal(actual, expected)
-
-
-def test_indexed_read_only_reads_requested_frames(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """An indexed read should pull only the requested planes off disk."""
-    uri = LOCAL_RESOURCES_DIR / "ND2_dims_p4z5t3c2y32x32.nd2"
-
-    rdr = Reader(uri)
-    rdr.set_scene(1)
-
-    # Selecting one T and one C leaves only the 5 Z planes to read, far fewer
-    # than the 3 * 5 * 2 = 30 frames in the full scene.
-    _, reads = _count_frame_reads(
-        monkeypatch, lambda: rdr.get_image_data("ZYX", T=1, C=0)
-    )
-    assert reads == 5
-
-
-def test_metadata_served_without_reading_frames(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``dims``/``shape``/``dtype`` come from metadata, reading no pixel data."""
-    uri = LOCAL_RESOURCES_DIR / "ND2_dims_p4z5t3c2y32x32.nd2"
-
-    def read_metadata() -> None:
-        rdr = Reader(uri)
-        rdr.set_scene(1)
-        _ = rdr.dims
-        _ = rdr.shape
-        _ = rdr.dtype
-
-    _, reads = _count_frame_reads(monkeypatch, read_metadata)
-    assert reads == 0
-
-
-def test_position_out_of_range_raises() -> None:
-    """Selecting a scene index beyond the available positions is an error."""
-    uri = LOCAL_RESOURCES_DIR / "ND2_dims_p4z5t3c2y32x32.nd2"
-    rdr = Reader(uri)
-    rdr._current_scene_index = 99
-    with pytest.raises(IndexError, match="out of range"):
-        rdr.dims

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "bioio-base>=3.0.0",
+  "bioio-base>=3.4.0",
   "nd2[legacy]>=0.10.3",
   "dask[array]>=2021.4.1",
   "fsspec>=2022.8.0",


### PR DESCRIPTION
## Summary
Speeds up sub-region access to ND2 files by reading only the requested planes off disk, and serves shape/dims/dtype from metadata without materializing the array.

- **Indexed reads** — add `_read_indexed` so `get_image_data(...)` reads only the requested frames one at a time, instead of constructing the full dask-backed xarray and slicing it.
- **Metadata-only `dims`/`shape`/`dtype`** — read sizes and dtype straight from the ND2 metadata (cached per scene), so these no longer trigger a delayed read.

Resolves #47 and #52
 
## Benchmark

I benchmarked against a 1Tb file with each scene being 250GB.
```
source:         /allen/programs/allencell/data/proj0/1ec/c24/341/f2b/c8a/3a9/e45/760/02a/524/76/3500008049_20251125_NIKON1_3.1_5.1.nd2
dims:           TZCYX
shape:          (56, 151, 4, 1952, 1952)
dtype:          uint16
pyramid levels: 5
  level 0: shape=(56, 151, 4, 1952, 1952)  chunk=(1, 1, 1, 1952, 1952)  shard=(1, 151, 3, 1952, 1952)  (3292.2 MiB uncompressed)
  level 1: shape=(56, 151, 4, 976, 976)  chunk=(1, 2, 1, 976, 976)  shard=(1, 152, 3, 976, 976)  (828.5 MiB uncompressed)
  level 2: shape=(56, 151, 4, 488, 488)  chunk=(1, 8, 1, 488, 488)  shard=(1, 152, 3, 488, 488)  (207.1 MiB uncompressed)
  level 3: shape=(56, 151, 4, 244, 244)  chunk=(1, 35, 1, 244, 244)  shard=(1, 175, 3, 244, 244)  (59.6 MiB uncompressed)
  level 4: shape=(56, 151, 4, 122, 122)  chunk=(1, 140, 1, 122, 122)  shard=(1, 280, 3, 122, 122)  (23.8 MiB uncompressed)
max workers:    12
output:         /allen/aics/users/brian.whitney/shard_benchmark3/3500008049_20251125_NIKON1_3_region_write.ome.zarr

derived n_workers: 12

Done.  elapsed: 1392.7s  (23.2 min)

```
Before this fix this file was basically unconvertible 
```
slurmstepd-n90: error: Job 1646435 exceeded memory limit (237553365 > 205520896), being killed
slurmstepd-n90: error: Exceeded job memory limit
slurmstepd-n90: error: *** JOB 1646435 ON n90 CANCELLED AT 2026-07-01T15:46:19 ***
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
