### PR TITLE
Populate time_interval and dimension unit metadata from ND2

### DIFF
--- a/bioio_nd2/reader.py
+++ b/bioio_nd2/reader.py
@@ -1,6 +1,7 @@
 import logging
 import re
-from typing import Any, Dict, Tuple
+from datetime import timedelta
+from typing import Any, Dict, Optional, Tuple
 
 import nd2
 import xarray as xr
@@ -133,6 +134,112 @@ class Reader(reader.Reader):
         with self._fs.open(self._path, "rb") as f:
             with nd2.ND2File(f) as rdr:
                 return types.PhysicalPixelSizes(*rdr.voxel_size()[::-1])
+
+    @staticmethod
+    def _time_period_ms(experiment: list) -> Optional[float]:
+        """Return the inter-frame interval in milliseconds from an ND2
+        experiment's time loop, or ``None`` if there isn't a single well-defined
+        interval.
+
+        A ``TimeLoop`` is equidistant, so its ``periodMs`` is the interval. A
+        ``NETimeLoop`` (non-equidistant) only has a single interval when it holds
+        exactly one period; with multiple periods there is no single value to
+        report.
+        """
+        for loop in experiment:
+            if isinstance(loop, nd2.structures.TimeLoop):
+                return loop.parameters.periodMs
+            if isinstance(loop, nd2.structures.NETimeLoop):
+                periods = loop.parameters.periods
+                if len(periods) == 1:
+                    return periods[0].periodMs
+        return None
+
+    @property
+    def time_interval(self) -> types.TimeInterval:
+        """
+        Returns
+        -------
+        interval: TimeInterval
+            The time between frames for dimension T as a ``datetime.timedelta``,
+            read from the ND2 experiment's time loop. ``None`` when the file has
+            no time loop with a single well-defined interval.
+        """
+        with self._fs.open(self._path, "rb") as f:
+            with nd2.ND2File(f) as rdr:
+                period_ms = self._time_period_ms(rdr.experiment)
+
+        if period_ms is None or period_ms <= 0:
+            return None
+        return timedelta(milliseconds=period_ms)
+
+    @staticmethod
+    def _ome_unit_to_pint(ome_unit: Any) -> Optional[types.Unit]:
+        """Convert an OME unit enum (e.g. ``UnitsLength.MICROMETER``) into a
+        ``pint.Unit`` from the shared BioIO registry, or ``None`` if it is
+        absent or unrecognized.
+
+        The OME enum's ``.value`` is the unit symbol (``"µm"``, ``"s"``), which
+        the shared registry (``bioio_base.types.ureg``) parses directly.
+        """
+        if ome_unit is None:
+            return None
+        try:
+            return types.ureg(ome_unit.value).units
+        except Exception:
+            return None
+
+    @property
+    def dimension_properties(self) -> types.DimensionProperties:
+        """
+        Per-dimension metadata describing semantic meaning and units.
+
+        Unlike the base Reader, which leaves all units as ``None``, this attaches
+        real ``pint.Unit`` instances read from the ND2 file's OME metadata (the
+        ``physical_size_*_unit`` and ``time_increment_unit`` fields) via the
+        shared registry ``bioio_base.types.ureg``. This lets downstream tooling
+        read a genuine, file-sourced unit from a consistent location rather than
+        assuming microns.
+        """
+        s = self.scale
+        if not hasattr(nd2.ND2File, "ome_metadata"):
+            return super().dimension_properties
+
+        try:
+            with self._fs.open(self._path, "rb") as f:
+                with nd2.ND2File(f) as rdr:
+                    pixels = rdr.ome_metadata().images[0].pixels
+        except Exception as err:
+            log.warning(f"Failed to read ND2 dimension units from OME metadata: {err}")
+            return super().dimension_properties
+
+        time_unit = self._ome_unit_to_pint(pixels.time_increment_unit)
+        z_unit = self._ome_unit_to_pint(pixels.physical_size_z_unit)
+        y_unit = self._ome_unit_to_pint(pixels.physical_size_y_unit)
+        x_unit = self._ome_unit_to_pint(pixels.physical_size_x_unit)
+
+        return types.DimensionProperties(
+            T=types.DimensionProperty(
+                type="time" if s.T is not None else None,
+                unit=time_unit if s.T is not None else None,
+            ),
+            C=types.DimensionProperty(
+                type="channel" if s.C is not None else None,
+                unit=None,
+            ),
+            Z=types.DimensionProperty(
+                type="space" if s.Z is not None else None,
+                unit=z_unit if s.Z is not None else None,
+            ),
+            Y=types.DimensionProperty(
+                type="space" if s.Y is not None else None,
+                unit=y_unit if s.Y is not None else None,
+            ),
+            X=types.DimensionProperty(
+                type="space" if s.X is not None else None,
+                unit=x_unit if s.X is not None else None,
+            ),
+        )
 
     @property
     def binning(self) -> str | None:

--- a/bioio_nd2/reader.py
+++ b/bioio_nd2/reader.py
@@ -137,14 +137,20 @@ class Reader(reader.Reader):
 
     @staticmethod
     def _time_period_ms(experiment: list) -> Optional[float]:
-        """Return the inter-frame interval in milliseconds from an ND2
-        experiment's time loop, or ``None`` if there isn't a single well-defined
-        interval.
+        """
+        Extract the inter-frame time interval, in milliseconds, from an ND2
+        experiment's time loop.
 
-        A ``TimeLoop`` is equidistant, so its ``periodMs`` is the interval. A
-        ``NETimeLoop`` (non-equidistant) only has a single interval when it holds
-        exactly one period; with multiple periods there is no single value to
-        report.
+        Parameters
+        ----------
+        experiment: list
+            The ND2 experiment loops, as returned by `nd2.ND2File.experiment`.
+
+        Returns
+        -------
+        period_ms: Optional[float]
+            The interval in milliseconds, or None when there is no time loop with
+            a single well-defined interval.
         """
         for loop in experiment:
             if isinstance(loop, nd2.structures.TimeLoop):
@@ -175,12 +181,21 @@ class Reader(reader.Reader):
 
     @staticmethod
     def _ome_unit_to_pint(ome_unit: Any) -> Optional[types.Unit]:
-        """Convert an OME unit enum (e.g. ``UnitsLength.MICROMETER``) into a
-        ``pint.Unit`` from the shared BioIO registry, or ``None`` if it is
-        absent or unrecognized.
+        """
+        Convert an OME unit enum into a `pint.Unit` from the shared BioIO
+        registry.
 
-        The OME enum's ``.value`` is the unit symbol (``"µm"``, ``"s"``), which
-        the shared registry (``bioio_base.types.ureg``) parses directly.
+        Parameters
+        ----------
+        ome_unit: Any
+            An OME unit enum (e.g. `UnitsLength.MICROMETER`), whose `.value` is
+            the unit symbol (`"µm"`, `"s"`) that `bioio_base.types.ureg` parses.
+
+        Returns
+        -------
+        unit: Optional[types.Unit]
+            The corresponding `pint.Unit`, or None if the input is absent or
+            unrecognized.
         """
         if ome_unit is None:
             return None
@@ -193,13 +208,6 @@ class Reader(reader.Reader):
     def dimension_properties(self) -> types.DimensionProperties:
         """
         Per-dimension metadata describing semantic meaning and units.
-
-        Unlike the base Reader, which leaves all units as ``None``, this attaches
-        real ``pint.Unit`` instances read from the ND2 file's OME metadata (the
-        ``physical_size_*_unit`` and ``time_increment_unit`` fields) via the
-        shared registry ``bioio_base.types.ureg``. This lets downstream tooling
-        read a genuine, file-sourced unit from a consistent location rather than
-        assuming microns.
         """
         s = self.scale
         if not hasattr(nd2.ND2File, "ome_metadata"):

--- a/bioio_nd2/tests/test_reader.py
+++ b/bioio_nd2/tests/test_reader.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from contextlib import nullcontext
+from datetime import timedelta
+from types import SimpleNamespace
 from typing import Any, List, Tuple, Union
 
 import numpy as np
@@ -216,3 +219,119 @@ def test_frame_metadata(cache: bool) -> None:
     assert isinstance(
         rdr.xarray_data.attrs["unprocessed"]["frame"], nd2.structures.FrameMetadata
     )
+
+
+def _make_timeloop(period_ms: float) -> Any:
+    return nd2.structures.TimeLoop(
+        count=1,
+        nestingLevel=0,
+        parameters=nd2.structures.TimeLoopParams(
+            startMs=0.0,
+            periodMs=period_ms,
+            durationMs=0.0,
+            periodDiff=nd2.structures.PeriodDiff(avg=0.0, max=0.0, min=0.0),
+        ),
+    )
+
+
+def _fake_nd2_for_experiment(experiment: List[Any]) -> Any:
+    class FakeND2File:
+        def __init__(self, file: object) -> None:
+            pass
+
+        def __enter__(self) -> "FakeND2File":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        @property
+        def experiment(self) -> List[Any]:
+            return experiment
+
+    return FakeND2File
+
+
+class _FakeFS:
+    def open(self, path: str, mode: str) -> Any:
+        return nullcontext(object())
+
+
+def test_time_interval_from_timeloop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "bioio_nd2.reader.nd2.ND2File",
+        _fake_nd2_for_experiment([_make_timeloop(360000.0)]),
+    )
+
+    rdr = Reader.__new__(Reader)
+    rdr._fs = _FakeFS()
+    rdr._path = "example.nd2"
+
+    assert rdr.time_interval == timedelta(milliseconds=360000.0)
+
+
+def test_time_interval_none_without_timeloop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "bioio_nd2.reader.nd2.ND2File",
+        _fake_nd2_for_experiment([]),
+    )
+
+    rdr = Reader.__new__(Reader)
+    rdr._fs = _FakeFS()
+    rdr._path = "example.nd2"
+
+    assert rdr.time_interval is None
+
+
+def test_dimension_properties_attach_units_from_ome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # OME unit enums expose the symbol via ``.value``, which the shared
+    # registry parses (µm -> micrometer, s -> second).
+    pixels = SimpleNamespace(
+        physical_size_x_unit=SimpleNamespace(value="µm"),
+        physical_size_y_unit=SimpleNamespace(value="µm"),
+        physical_size_z_unit=SimpleNamespace(value="µm"),
+        time_increment_unit=SimpleNamespace(value="s"),
+    )
+    ome = SimpleNamespace(images=[SimpleNamespace(pixels=pixels)])
+
+    class FakeND2File:
+        def __init__(self, file: object) -> None:
+            pass
+
+        def __enter__(self) -> "FakeND2File":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        @property
+        def experiment(self) -> List[Any]:
+            return [_make_timeloop(1000.0)]
+
+        def voxel_size(self) -> Tuple[float, float, float]:
+            return (0.5, 0.5, 2.0)
+
+        def ome_metadata(self) -> Any:
+            return ome
+
+    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
+
+    rdr = Reader.__new__(Reader)
+    rdr._fs = _FakeFS()
+    rdr._path = "example.nd2"
+
+    dp = rdr.dimension_properties
+
+    assert dp.T.type == "time"
+    assert str(dp.T.unit) == "second"
+    assert dp.C.type is None
+    assert dp.C.unit is None
+    for axis in (dp.Z, dp.Y, dp.X):
+        assert axis.type == "space"
+        assert str(axis.unit) == "micrometer"

--- a/bioio_nd2/tests/test_reader.py
+++ b/bioio_nd2/tests/test_reader.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from contextlib import nullcontext
 from datetime import timedelta
-from types import SimpleNamespace
 from typing import Any, List, Tuple, Union
 
 import numpy as np
@@ -221,117 +219,70 @@ def test_frame_metadata(cache: bool) -> None:
     )
 
 
-def _make_timeloop(period_ms: float) -> Any:
-    return nd2.structures.TimeLoop(
-        count=1,
-        nestingLevel=0,
-        parameters=nd2.structures.TimeLoopParams(
-            startMs=0.0,
-            periodMs=period_ms,
-            durationMs=0.0,
-            periodDiff=nd2.structures.PeriodDiff(avg=0.0, max=0.0, min=0.0),
+@pytest.mark.parametrize(
+    "filename, expected_interval",
+    [
+        # Time-lapse files carry a TimeLoop, so time_interval is populated.
+        ("ND2_jonas_header_test2.nd2", timedelta(seconds=5)),
+        ("ND2_dims_rgb_t3p2c2z3x64y64.nd2", timedelta(seconds=1)),
+        ("ND2_dims_t3c2y32x32.nd2", timedelta(milliseconds=1)),
+        # Legacy file (no OME metadata) still exposes its experiment loop.
+        ("ND2_aryeh_but3_cont200-1.nd2", timedelta(minutes=15)),
+        # Files without a time loop report no interval.
+        ("ND2_dims_c2y32x32.nd2", None),
+        ("ND2_maxime_BF007.nd2", None),
+    ],
+)
+def test_time_interval(
+    filename: str,
+    expected_interval: object,
+) -> None:
+    rdr = Reader(LOCAL_RESOURCES_DIR / filename)
+
+    assert rdr.time_interval == expected_interval
+
+
+@pytest.mark.parametrize(
+    "filename, expected_t, expected_space",
+    [
+        # Time-lapse with OME metadata: seconds on T, microns on ZYX.
+        (
+            "ND2_jonas_header_test2.nd2",
+            ("time", "second"),
+            "micrometer",
         ),
-    )
-
-
-def _fake_nd2_for_experiment(experiment: List[Any]) -> Any:
-    class FakeND2File:
-        def __init__(self, file: object) -> None:
-            pass
-
-        def __enter__(self) -> "FakeND2File":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-        @property
-        def experiment(self) -> List[Any]:
-            return experiment
-
-    return FakeND2File
-
-
-class _FakeFS:
-    def open(self, path: str, mode: str) -> Any:
-        return nullcontext(object())
-
-
-def test_time_interval_from_timeloop(
-    monkeypatch: pytest.MonkeyPatch,
+        # No time loop: T carries no type/unit; ZYX still microns.
+        (
+            "ND2_dims_c2y32x32.nd2",
+            (None, None),
+            "micrometer",
+        ),
+        # Legacy file: no OME metadata, so units fall back to None while the
+        # semantic types are still derived from the (present) scale.
+        (
+            "ND2_aryeh_but3_cont200-1.nd2",
+            ("time", None),
+            None,
+        ),
+    ],
+)
+def test_dimension_properties(
+    filename: str,
+    expected_t: Tuple[object, object],
+    expected_space: object,
 ) -> None:
-    monkeypatch.setattr(
-        "bioio_nd2.reader.nd2.ND2File",
-        _fake_nd2_for_experiment([_make_timeloop(360000.0)]),
-    )
-
-    rdr = Reader.__new__(Reader)
-    rdr._fs = _FakeFS()
-    rdr._path = "example.nd2"
-
-    assert rdr.time_interval == timedelta(milliseconds=360000.0)
-
-
-def test_time_interval_none_without_timeloop(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        "bioio_nd2.reader.nd2.ND2File",
-        _fake_nd2_for_experiment([]),
-    )
-
-    rdr = Reader.__new__(Reader)
-    rdr._fs = _FakeFS()
-    rdr._path = "example.nd2"
-
-    assert rdr.time_interval is None
-
-
-def test_dimension_properties_attach_units_from_ome(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # OME unit enums expose the symbol via ``.value``, which the shared
-    # registry parses (µm -> micrometer, s -> second).
-    pixels = SimpleNamespace(
-        physical_size_x_unit=SimpleNamespace(value="µm"),
-        physical_size_y_unit=SimpleNamespace(value="µm"),
-        physical_size_z_unit=SimpleNamespace(value="µm"),
-        time_increment_unit=SimpleNamespace(value="s"),
-    )
-    ome = SimpleNamespace(images=[SimpleNamespace(pixels=pixels)])
-
-    class FakeND2File:
-        def __init__(self, file: object) -> None:
-            pass
-
-        def __enter__(self) -> "FakeND2File":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            pass
-
-        @property
-        def experiment(self) -> List[Any]:
-            return [_make_timeloop(1000.0)]
-
-        def voxel_size(self) -> Tuple[float, float, float]:
-            return (0.5, 0.5, 2.0)
-
-        def ome_metadata(self) -> Any:
-            return ome
-
-    monkeypatch.setattr("bioio_nd2.reader.nd2.ND2File", FakeND2File)
-
-    rdr = Reader.__new__(Reader)
-    rdr._fs = _FakeFS()
-    rdr._path = "example.nd2"
+    rdr = Reader(LOCAL_RESOURCES_DIR / filename)
 
     dp = rdr.dimension_properties
 
-    assert dp.T.type == "time"
-    assert str(dp.T.unit) == "second"
+    expected_t_type, expected_t_unit = expected_t
+    assert dp.T.type == expected_t_type
+    assert (str(dp.T.unit) if dp.T.unit is not None else None) == expected_t_unit
+
+    # Channels never carry a spatial/temporal unit.
     assert dp.C.type is None
     assert dp.C.unit is None
+
     for axis in (dp.Z, dp.Y, dp.X):
         assert axis.type == "space"
-        assert str(axis.unit) == "micrometer"
+        assert (str(axis.unit) if axis.unit is not None else None) == expected_space


### PR DESCRIPTION
Closes #50

## Summary
Surfaces file-sourced units and the acquisition frame interval through `BioImage.dimension_properties` / `scale` location.

- **`time_interval`** — new override reading the inter-frame interval from the ND2 experiment's `TimeLoop` (`periodMs`), or a single-period `NETimeLoop`, returned as a `datetime.timedelta`. This makes `scale.T` correct. Returns `None` when there is no single well-defined interval (e.g. multi-period `NETimeLoop`).
- **`dimension_properties`** — new override that attaches real `pint.Unit` instances (via the shared `bioio_base.types.ureg` registry) 
- 
## Example
For a Z-stack timelapse ND2 (`0.1625 µm` XY, `1.0 µm` Z, `360 s` frame interval):

| axis | before | after |
| --- | --- | --- |
| T | `type=None, unit=None`, `scale.T=None` | `type=time, unit=second`, `scale.T=360.0` |
| Z/Y/X | `type=space, unit=None` | `type=space, unit=micrometer` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)