### PR TITLE
Bugfix: Use 1-indexed integer well row identifiers

### DIFF
--- a/bioio_nd2/plates.py
+++ b/bioio_nd2/plates.py
@@ -18,7 +18,8 @@ class WellPosition:
     """
     Logical well identifier.
 
-    This represents a *logical* plate position (e.g. "A1", "H12") and does
+    This represents a *logical* plate position (e.g. row "1" col "1",
+    row "8" col "12") and does
     not encode any physical geometry. It is intentionally lightweight so it
     can be stored directly in standardized metadata.
     """
@@ -101,7 +102,7 @@ class Plate:
         Human-readable identifier for the plate geometry (e.g. "96", "384").
 
     rows : List[str]
-        Ordered list of row identifiers (e.g. ["A", "B", ..., "H"]).
+        Ordered list of row identifiers (e.g. ["1", "2", ..., "8"]).
         The order defines the physical row layout on the plate.
 
     cols : List[str]
@@ -229,7 +230,7 @@ class Plate:
 # Standard 96-well plate geometry.
 PLATE_96 = Plate(
     name="96",
-    rows=list("ABCDEFGH")[::-1],
+    rows=[str(i) for i in range(1, 9)][::-1],
     cols=[str(i) for i in range(1, 13)],
     plate_width_mm=126.6,
     plate_height_mm=85.7,

--- a/bioio_nd2/tests/test_standard_metadata.py
+++ b/bioio_nd2/tests/test_standard_metadata.py
@@ -140,25 +140,25 @@ def test_nd2_standard_metadata(filename: str, expected: dict[str, Any]) -> None:
     "filename, scene_index, expected_row, expected_col",
     [
         # Case 1: ND2 file without an XYPosLoop. The stage position is
-        # recovered from the events table and lands inside well D6.
+        # recovered from the events table and lands inside well row 4, col 6.
         (
             "ND2_maxime_BF007.nd2",
             0,
-            "D",
+            "4",
             "6",
         ),
-        # Case 2: Plate scan file, scene maps to E3
+        # Case 2: Plate scan file, scene maps to row 5, col 3
         (
             "ND2_dims_rgb_t3p2c2z3x64y64.nd2",
             0,
-            "E",
+            "5",
             "3",
         ),
-        # Case 3: Same file, different scene maps to E2
+        # Case 3: Same file, different scene maps to row 5, col 2
         (
             "ND2_dims_rgb_t3p2c2z3x64y64.nd2",
             1,
-            "E",
+            "5",
             "2",
         ),
     ],

--- a/bioio_nd2/tests/test_standard_metadata.py
+++ b/bioio_nd2/tests/test_standard_metadata.py
@@ -39,7 +39,7 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Pixel Size Y": 0.652452890023035,
                 "Pixel Size Z": 1.0,
                 "Position Index": None,
-                "Row": "D",
+                "Row": "4",
                 "Timelapse": True,
                 "Timelapse Interval": datetime.timedelta(
                     seconds=18, microseconds=495260
@@ -76,7 +76,7 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Pixel Size Y": 0.652452890023035,
                 "Pixel Size Z": 1.0,
                 "Position Index": None,
-                "Row": "D",
+                "Row": "4",
                 "Timelapse": True,
                 "Timelapse Interval": datetime.timedelta(
                     seconds=4, microseconds=293375
@@ -115,7 +115,7 @@ from .conftest import LOCAL_RESOURCES_DIR
                 "Pixel Size Y": 0.108333333333333,
                 "Pixel Size Z": 0.5,
                 "Position Index": None,
-                "Row": "E",
+                "Row": "5",
                 "Timelapse": False,
                 "Timelapse Interval": None,
                 "Total Time Duration": datetime.timedelta(microseconds=245184),


### PR DESCRIPTION
## Summary

Well plate `row` identifiers were letter-indexed (`"A"`–`"H"`) while `col` identifiers were 1-indexed integers (`"1"`–`"12"`). This made the well coordinate inconsistent and forced downstream consumers of the standardized `row`/`column` metadata to special-case alphabetic rows.

This makes `row` a 1-indexed integer string (`"1"`–`"8"`) to match `col`, so the well coordinate is uniform.

## Changes

- `plates.py`: `rows=list("ABCDEFGH")[::-1]` → `rows=[str(i) for i in range(1, 9)][::-1]`. The `[::-1]` reversal is preserved so the physical row layout — and therefore well-to-stage assignment geometry — is unchanged (`A`→`"1"`, `B`→`"2"`, … `H`→`"8"`).
- Updated `WellPosition` / `Plate.rows` docstrings that referenced letter rows.
- Updated `test_standard_metadata.py` assertions accordingly (`D`→`"4"`, `E`→`"5"`).

## Testing

`test_nd2_scene_row_and_column` passes (3/3), confirming the letter→number mapping.

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)